### PR TITLE
Bug Fixes and Optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN chmod o+w ./storage/ -R
 RUN chmod o+w ./public/ -R
 
 # Copy .env and set up Laravel
-RUN cp .env.example .env && php artisan key:generate && php artisan reverb:generate && php artisan storage:link
+RUN cp .env.example .env && php artisan storage:link
 
 FROM node:22 AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /var/www/html
 COPY . .
 
 
-RUN composer install --optimize-autoloader --no-interaction --no-scripts
+RUN composer install --no-dev --optimize-autoloader --no-interaction --no-scripts
 RUN chmod o+w ./storage/ -R
 RUN chmod o+w ./public/ -R
 

--- a/app/Console/Commands/GenerateReverbKeys.php
+++ b/app/Console/Commands/GenerateReverbKeys.php
@@ -23,24 +23,30 @@ class GenerateReverbKeys extends Command {
      * Execute the console command.
      */
     public function handle() {
+        $envPath = base_path('.env');
+
+        if (! file_exists($envPath)) {
+            return false;
+        }
+
+        if ($this->keysExist()) {
+            return false;
+        }
+
         $reverbAppId = random_int(100000, 999999);
         $reverbAppKey = bin2hex(random_bytes(16));
         $reverbAppSecret = bin2hex(random_bytes(16));
 
-        $this->setEnvironmentValue('REVERB_APP_ID', $reverbAppId);
-        $this->setEnvironmentValue('REVERB_APP_KEY', $reverbAppKey);
-        $this->setEnvironmentValue('REVERB_APP_SECRET', $reverbAppSecret);
+        $this->setEnvironmentValue('REVERB_APP_ID', $reverbAppId, $envPath);
+        $this->setEnvironmentValue('REVERB_APP_KEY', $reverbAppKey, $envPath);
+        $this->setEnvironmentValue('REVERB_APP_SECRET', $reverbAppSecret, $envPath);
 
         $this->info('Reverb keys generated and updated in .env file.');
     }
 
     // Helper method to set the values in the .env file
-    protected function setEnvironmentValue($key, $value) {
+    protected function setEnvironmentValue($key, $value, $envPath) {
         $envPath = base_path('.env');
-
-        if (! file_exists($envPath)) {
-            return;
-        }
 
         $content = file_get_contents($envPath);
         $pattern = "/^$key=[^\n]*/m";
@@ -51,5 +57,21 @@ class GenerateReverbKeys extends Command {
         if ($newContent !== null) {
             file_put_contents($envPath, $newContent);
         }
+    }
+
+    protected function keysExist() {
+        $reverbAppId = (int) env('REVERB_APP_ID');
+        $reverbAppKey = env('REVERB_APP_KEY', '');
+        $reverbAppSecret = env('REVERB_APP_SECRET', '');
+
+        if ($reverbAppId < 100000 || $reverbAppId > 999999) {
+            return false;
+        }
+
+        if (strlen($reverbAppKey) < 20 || strlen($reverbAppSecret) < 20) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/Events/LibraryUpdated.php
+++ b/app/Events/LibraryUpdated.php
@@ -42,6 +42,6 @@ class LibraryUpdated implements ShouldBroadcast {
      * Get the data to broadcast.
      */
     public function broadcastWith(): array {
-        return ['library' => new CategoryResource($this->library)];
+        return ['library' => new CategoryResource($this->library->withCount('folders'))];
     }
 }

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -29,7 +29,7 @@ class CategoryController extends Controller {
 
             return $this->success(
                 CategoryResource::collection(
-                    $categories->get()
+                    $categories->with(['folders.series'])->get()
                 )
             );
         } catch (\Throwable $th) {
@@ -45,6 +45,7 @@ class CategoryController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function show(Category $category) {
+        $category->load(['folders.series']);
         return new CategoryResource($category);
     }
 

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -29,7 +29,7 @@ class CategoryController extends Controller {
 
             return $this->success(
                 CategoryResource::collection(
-                    $categories->withCount(['folders', 'videos'])->with(['folders.series'])->get()
+                    $categories->with(['folders.series'])->get()
                 )
             );
         } catch (\Throwable $th) {
@@ -46,7 +46,7 @@ class CategoryController extends Controller {
      */
     public function show(Category $category) {
         $category->load(['folders.series']);
-        return new CategoryResource($category->withCount(['folders', 'videos']));
+        return new CategoryResource($category);
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -46,6 +46,7 @@ class CategoryController extends Controller {
      */
     public function show(Category $category) {
         $category->load(['folders.series']);
+
         return new CategoryResource($category);
     }
 

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -21,7 +21,7 @@ class CategoryController extends Controller {
             abort(403, 'Unauthorized action.');
         }
         try {
-            $categories = Category::withCount('videos')->orderBy('name');
+            $categories = Category::orderBy('name');
 
             if (Auth::user()->id !== 1) {
                 $categories->where('is_private', false);
@@ -29,7 +29,7 @@ class CategoryController extends Controller {
 
             return $this->success(
                 CategoryResource::collection(
-                    $categories->with(['folders.series'])->get()
+                    $categories->withCount(['folders', 'videos'])->with(['folders.series'])->get()
                 )
             );
         } catch (\Throwable $th) {
@@ -46,7 +46,7 @@ class CategoryController extends Controller {
      */
     public function show(Category $category) {
         $category->load(['folders.series']);
-        return new CategoryResource($category);
+        return new CategoryResource($category->withCount(['folders', 'videos']));
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/FolderController.php
+++ b/app/Http/Controllers/Api/V1/FolderController.php
@@ -29,7 +29,7 @@ class FolderController extends Controller {
         try {
             return $this->success(
                 FolderResource::collection(
-                    Folder::with(['videos.metadata', 'series'])->where('category_id', $validated['category_id'])->orderBy('id')->get()
+                    Folder::with(['series'])->where('category_id', $validated['category_id'])->orderBy('id')->get() // do not eager load videos... because in this instance, the request is not asking for videos, simply a list of folders
                 )
             );
         } catch (\Throwable $th) {
@@ -45,7 +45,7 @@ class FolderController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function show(Folder $folder) {
-        $folder->load(['videos.metadata', 'series']);
+        $folder->load(['videos.metadata.videoTags.tag', 'series']);
 
         return new FolderResource($folder);
     }

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -19,7 +19,7 @@ class MetadataController extends Controller {
     public function show($id) {
         try {
             return $this->success(
-                new MetadataResource(Metadata::where('id', $id)->first())
+                new MetadataResource(Metadata::with(['videoTags.tag'])->where('id', $id)->first())
             );
         } catch (\Throwable $th) {
             return $this->error(null, 'Unable to get data. Error: ' . $th->getMessage(), 500);

--- a/app/Http/Controllers/Api/V1/PlaybackController.php
+++ b/app/Http/Controllers/Api/V1/PlaybackController.php
@@ -18,10 +18,9 @@ class PlaybackController extends Controller {
     /**
      * Display a listing of the resource.
      * Get all playback data points from metadata ID for a video
+     * Ordered By Progress 0 -> 100
      */
     public function show(int $id) {
-        // $request->query('param');
-
         try {
             return Playback::where('metadata_id', $id)->oldest('progress')->get();
         } catch (\Throwable $th) {

--- a/app/Http/Controllers/Api/V1/RecordController.php
+++ b/app/Http/Controllers/Api/V1/RecordController.php
@@ -18,19 +18,17 @@ class RecordController extends Controller {
      * Display a listing of the resource.
      */
     public function index(Request $request) {
+        $records = Record::where('user_id', Auth::id())->with('metadata.video.folder.category')->latest();
+
         if (isset($request->limit) && is_numeric($request->limit)) {
-            return $this->success(
-                RecordResource::collection(
-                    Record::where('user_id', Auth::id())->latest()->limit($request->limit)->get()
-                )
-            );
-        } else {
-            return $this->success(
-                RecordResource::collection(
-                    Record::where('user_id', Auth::id())->latest()->get()
-                )
-            );
+            $records->limit($request->limit);
         }
+
+        return $this->success(
+            RecordResource::collection(
+                $records->get()
+            )
+        );
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/VideoController.php
+++ b/app/Http/Controllers/Api/V1/VideoController.php
@@ -65,13 +65,13 @@ class VideoController extends Controller {
      * @return \Illuminate\Http\Response
      */
     public function watch(Request $request, Video $video) {
-        $metadata = $video->metadata()->first();
+        $metadata = $video->metadata();
         if ($metadata) {
             $metadata->update(['view_count' => ($metadata->view_count ?? 0) + 1]);
         } else {
             $video->update(['view_count' => ($video->view_count ?? 0) + 1]);
         }
 
-        return $this->success(new VideoResource($video));
+        return $this->success(new VideoResource($video->load('metadata.videoTags.tag')));
     }
 }

--- a/app/Http/Controllers/Api/V1/VideoController.php
+++ b/app/Http/Controllers/Api/V1/VideoController.php
@@ -70,9 +70,9 @@ class VideoController extends Controller {
 
         // Only update view count via metadata if it exists (ie do not reset)
         if (isset($metadata->view_count)) {
-            $metadata->update(['view_count' => $metadata->view_count  + 1]);
+            $metadata->update(['view_count' => $metadata->view_count + 1]);
         } else {
-            $metadata->update(['view_count' => Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0)  + 1]);
+            $metadata->update(['view_count' => Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0) + 1]);
         }
 
         return $this->success(new VideoResource($video->load('metadata.videoTags.tag')));

--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -56,8 +56,8 @@ class DirectoryController extends Controller {
 
             $data = ['dir' => ['id' => null, 'name' => $dir, 'folders' => null], 'folder' => ['id' => null, 'name' => $folderName ?? null, 'videos' => null]]; // Default null values
 
-            $folderList = Folder::with('series')->where('category_id', $dirRaw->id)->withCount(['videos'])->orderBy('name'); // Folders in category
-            $data['dir'] = ['id' => $dirRaw->id, 'name' => $dir, 'folders' => FolderResource::collection($folderList->get())]; // Full category data
+            $folderList = Folder::with('series')->where('category_id', $dirRaw->id)->orderBy('name')->get(); // Folders in category
+            $data['dir'] = ['id' => $dirRaw->id, 'name' => $dir, 'folders' => FolderResource::collection($folderList)]; // Full category data
 
             $folderRaw = isset($request->folderName)
                 ? (

--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -79,7 +79,7 @@ class DirectoryController extends Controller {
                 return $this->error(['categoryName' => $dir, 'folderName' => $folderName], 'Cannot find folder in specified category', 404);
             }
 
-            $folderRaw->load(['videos.metadata.videoTags']);
+            $folderRaw->load(['videos.metadata.videoTags.tag']);
 
             $videoList = VideoResource::collection($folderRaw->videos); // VideoResource::collection(Video::where('folder_id', $folderRaw->id)->get());
             $data['folder'] = ['id' => $folderRaw->id, 'name' => $folderRaw->name, 'videos' => $videoList, 'series' => $data['dir']['folders']->first(function ($folder) use ($folderRaw) {

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Log;
 
 class CategoryResource extends JsonResource {
     /**
@@ -12,13 +13,20 @@ class CategoryResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
+
+        $folders = $this->whenLoaded('folders');
+
+        $videosCount = $folders->sum(function ($folder) {
+            return $folder->video_count ?? $folder->series->episodes;
+        });
+
         return [
             'id' => (string) $this->id,
             'name' => $this->name,
             'default_folder_id' => $this->default_folder_id,
-            'folders_count' => $this->folders_count ?? 0,
-            'folders' => FolderResource::collection($this->folders),
-            'videos_count' => $this->videos_count ?? 0,
+            'folders_count' => count($folders) ?? 0,
+            'folders' => FolderResource::collection($folders),
+            'videos_count' => $videosCount ?? 0,
             'created_at' => $this->created_at,
             'last_scan' => $this->last_scan,
         ];

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -22,13 +22,18 @@ class CategoryResource extends JsonResource {
             return $folder->video_count ?? $folder->series->episodes;
         });
 
+        $totalSize = $folders->sum(function ($folder) {
+            return $folder->series->total_size;
+        });
+
         return [
             'id' => (string) $this->id,
             'name' => $this->name,
             'default_folder_id' => $this->default_folder_id,
-            'folders_count' => count($folders) ?? 0,
             'folders' => FolderResource::collection($folders),
+            'folders_count' => count($folders) ?? 0,
             'videos_count' => $videosCount ?? 0,
+            'total_size' => $totalSize ?? 0,
             'created_at' => $this->created_at,
             'last_scan' => $this->last_scan,
         ];

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -12,7 +12,11 @@ class CategoryResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        $folders = $this->whenLoaded('folders');
+        if (! $this->relationLoaded('folders')) {
+            $this->loadMissing('folders');
+        }
+
+        $folders = $this->folders;
 
         $videosCount = $folders->sum(function ($folder) {
             return $folder->video_count ?? $folder->series->episodes;

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -4,7 +4,6 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Support\Facades\Log;
 
 class CategoryResource extends JsonResource {
     /**
@@ -13,7 +12,6 @@ class CategoryResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-
         $folders = $this->whenLoaded('folders');
 
         $videosCount = $folders->sum(function ($folder) {

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -4,7 +4,6 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Support\Facades\DB;
 
 class CategoryResource extends JsonResource {
     /**
@@ -19,9 +18,7 @@ class CategoryResource extends JsonResource {
             'default_folder_id' => $this->default_folder_id,
             'folders_count' => $this->folders_count ?? 0,
             'folders' => FolderResource::collection($this->folders),
-            'videos_count' => $this->videos_count ?? $this->when(true, function () {
-                return DB::table('videos')->join('folders', 'videos.folder_id', '=', 'folders.id')->join('categories', 'folders.category_id', '=', 'categories.id')->where('categories.id', $this->id)->count('videos.id');
-            }),
+            'videos_count' => $this->videos_count ?? 0,
             'created_at' => $this->created_at,
             'last_scan' => $this->last_scan,
         ];

--- a/app/Http/Resources/FolderResource.php
+++ b/app/Http/Resources/FolderResource.php
@@ -11,12 +11,13 @@ class FolderResource extends JsonResource {
      *
      * @return array<string, mixed>
      */
+
     public function toArray(Request $request): array {
         return [
             'id' => $this->id,
             'name' => $this->name,
             'path' => $this->path,
-            'file_count' => $this->videos_count ?? 0, // $videos->count(),
+            'file_count' => $this->videos_count ?? $this->series->episodes ?? 0, // $videos->count(),
             'total_size' => $this->series->total_size,
             'category_id' => $this->category_id,
             'videos' => $this->when($request->videos, function () {
@@ -27,29 +28,3 @@ class FolderResource extends JsonResource {
         ];
     }
 }
-
-/*
-Mega Yikes AI code
-protected static $categoryCache = [];
-
-$videos = $request->videos ? $this->videos : [];
-
-$totalFileSize = $this->videos->sum(function ($video) {
-return $video->metadata ? $video->metadata->file_size : 0;
-});
-$self = Folder::with('videos.metadata')->find($this->id);
-
-$categoryId = $this->category_id; // Assuming editor_id is the foreign key
-$category = null;
-
-if (isset(self::$categoryCache[$categoryId])) {
-    $category = self::$categoryCache[$categoryId];
-} else {
-    $category = $this->category;
-    self::$categoryCache[$categoryId] = $category;
-}
-
-'total_size' => $this->videos->sum(function ($video) {
-    return $video->metadata ? $video->metadata->file_size : 0;
-}),
-*/

--- a/app/Http/Resources/FolderResource.php
+++ b/app/Http/Resources/FolderResource.php
@@ -11,7 +11,6 @@ class FolderResource extends JsonResource {
      *
      * @return array<string, mixed>
      */
-
     public function toArray(Request $request): array {
         return [
             'id' => $this->id,

--- a/app/Http/Resources/RecordResource.php
+++ b/app/Http/Resources/RecordResource.php
@@ -6,62 +6,18 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class RecordResource extends JsonResource {
-    // Mega Yikes AI code
-    protected static $categoryCache = [];
-
-    protected static $folderCache = [];
-
-    protected static $metadataCache = [];
-
-    protected static $videoCache = [];
-
     /**
      * Transform the resource into an array.
      *
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        $metadata = null;
-        $video = null;
-        $folder = null;
-        $category = null;
 
-        $metadataId = $this->metadata_id;
 
-        if (isset(self::$metadataCache[$metadataId])) {
-            $metadata = self::$metadataCache[$metadataId];
-        } else {
-            $metadata = $this->metadata;
-            self::$metadataCache[$metadataId] = $metadata;
-        }
-
-        $videoId = $metadata?->video_id ?? $this?->video_id;
-
-        if (isset(self::$videoCache[$videoId])) {
-            $video = self::$videoCache[$videoId];
-        } else {
-            $video = $metadata?->video_id ? $metadata?->video : $this->video;
-            self::$videoCache[$videoId] = $video;
-        }
-
-        $folderId = $video?->folder_id;
-
-        if ($folderId) {
-            if (isset(self::$folderCache[$folderId])) {
-                $folder = self::$folderCache[$folderId];
-            } else {
-                $folder = $video->folder;
-                self::$folderCache[$folderId] = $folder;
-            }
-
-            $categoryId = $folder->category_id;
-            if (isset(self::$categoryCache[$categoryId])) {
-                $category = self::$categoryCache[$categoryId];
-            } else {
-                $category = $folder->category;
-                self::$categoryCache[$categoryId] = $category;
-            }
-        }
+        $metadata = $this->metadata;
+        $video = $metadata?->video;
+        $folder = $video?->folder;
+        $category = $folder?->category;
 
         return [
             'id' => (string) $this->id,
@@ -73,27 +29,10 @@ class RecordResource extends JsonResource {
                 'folder' => $folder ?? ['name' => 'Unknown'],
                 'metadata' => $metadata,
                 'category' => $category,
-                'video_id' => $videoId,
-                'video_name' => $metadata->title ?? $this->name ?? 'Deleted',
+                'video_id' => $this->video_id ?? $metadata->video_id ?? null,
+                'video_name' => $metadata->title ?? $video->name ?? $this->name ?? 'Deleted',
                 'file_name' => $this->name,
             ],
         ];
     }
 }
-
-// 'user' => $this->user,
-// 'video' => $video,
-// 'metadata' => $metadata ? new MetadataResource($metadata) : null,
-// 'category' => $category ? new CategoryResource($category) : null,
-
-// 'user' => $this->user,
-// 'video' => $this->video,
-// 'user_id' => (string)$this->user->id,
-// 'user_name' => $this->user->name,
-// 'video_id' => $this->video ? (string)$this->video->id : ($this->metadata && $this->metadata->video ? $this->metadata->video->id : null),
-// 'video_name' => $this->metadata ? $this->metadata->title : ($this->video ? ($this->video->title ?? $this->video->name) : $this->name) ?? 'Deleted',
-// 'file_name' => $this->video ? $this->video->name : $this->name,
-// 'folder' => $this->video ? new FolderResource($this->video->folder) : array("name" => ($this->metadata && $this->metadata->video ? $this->metadata->video->folder->name : 'Unknown')),
-// 'category' => $this->video && $this->video->folder->category ? new CategoryResource($this->video->folder->category) : null,
-// 'metadata_id' => $this->metadata ? $this->metadata->id : 'None',
-// 'metadata' => $this->metadata ? new MetadataResource($this->metadata) : null,

--- a/app/Http/Resources/RecordResource.php
+++ b/app/Http/Resources/RecordResource.php
@@ -12,8 +12,6 @@ class RecordResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-
-
         $metadata = $this->metadata;
         $video = $metadata?->video;
         $folder = $video?->folder;

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -12,7 +12,7 @@ class VideoResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        if (!$this->relationLoaded('metadata')) {
+        if (! $this->relationLoaded('metadata')) {
             $this->loadMissing('metadata');
         }
 

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -12,14 +12,18 @@ class VideoResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        $metadata = $this->whenLoaded('metadata');
+        if (!$this->relationLoaded('metadata')) {
+            $this->loadMissing('metadata');
+        }
+
+        $metadata = $this->metadata;
 
         return [
             'id' => (string) $this->id,
             'name' => $this->name,
             'path' => $this->path,
             'date' => $this->date,
-            'title' => $metadata?->title ?: $this->title ?: $this->name,
+            'title' => $metadata?->title ?: $this->name,
             'description' => $metadata?->description ?: $this->description, // ?: $this->folder->series->description
             'duration' => $metadata?->duration ?: $this->duration,
             'episode' => $metadata?->episode ?: $this->episode,
@@ -28,7 +32,7 @@ class VideoResource extends JsonResource {
             'file_size' => $metadata?->file_size ?: null,
             'video_tags' => $this->whenLoaded(
                 'metadata',
-                fn () => VideoTagResource::collection($metadata->videoTags)
+                fn() => VideoTagResource::collection($metadata->videoTags)
             ),
             'date_released' => $metadata?->date_released ?: null,
             'date_updated' => $metadata?->updated_at ?: null,

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -30,10 +30,7 @@ class VideoResource extends JsonResource {
             'season' => $metadata?->season ?: $this->season,
             'view_count' => $metadata?->view_count ?: $this->view_count,
             'file_size' => $metadata?->file_size ?: null,
-            'video_tags' => $this->whenLoaded(
-                'metadata',
-                fn() => VideoTagResource::collection($metadata->videoTags)
-            ),
+            'video_tags' => VideoTagResource::collection($metadata->videoTags ?? []),
             'date_released' => $metadata?->date_released ?: null,
             'date_updated' => $metadata?->updated_at ?: null,
             'date_uploaded' => $metadata?->date_uploaded ?: null,

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -28,7 +28,7 @@ class VideoResource extends JsonResource {
             'file_size' => $metadata?->file_size ?: null,
             'video_tags' => $this->whenLoaded(
                 'metadata',
-                fn() => VideoTagResource::collection($metadata->videoTags)
+                fn () => VideoTagResource::collection($metadata->videoTags)
             ),
             'date_released' => $metadata?->date_released ?: null,
             'date_updated' => $metadata?->updated_at ?: null,

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -12,7 +12,7 @@ class VideoResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        $metadata = $this->metadata;
+        $metadata = $this->whenLoaded('metadata');
 
         return [
             'id' => (string) $this->id,
@@ -26,7 +26,10 @@ class VideoResource extends JsonResource {
             'season' => $metadata?->season ?: $this->season,
             'view_count' => $metadata?->view_count ?: $this->view_count,
             'file_size' => $metadata?->file_size ?: null,
-            'video_tags' => VideoTagResource::collection($metadata?->videotags ?: []),
+            'video_tags' => $this->whenLoaded(
+                'metadata',
+                fn() => VideoTagResource::collection($metadata->videoTags)
+            ),
             'date_released' => $metadata?->date_released ?: null,
             'date_updated' => $metadata?->updated_at ?: null,
             'date_uploaded' => $metadata?->date_uploaded ?: null,

--- a/app/Http/Resources/VideoTagResource.php
+++ b/app/Http/Resources/VideoTagResource.php
@@ -25,7 +25,7 @@ class VideoTagResource extends JsonResource {
 
         return [
             'video_tag_id' => $this->id,
-            'name' => $this->whenLoaded('tag', fn() => $this->tag->name),
+            'name' => $this->whenLoaded('tag', fn () => $this->tag->name),
             'id' => $this->tag_id,
         ];
     }

--- a/app/Http/Resources/VideoTagResource.php
+++ b/app/Http/Resources/VideoTagResource.php
@@ -23,9 +23,15 @@ class VideoTagResource extends JsonResource {
         // self::$tagCache[$tag_id] = $tag;
         // }
 
+        if (! $this->relationLoaded('tag')) {
+            $this->loadMissing('tag');
+        }
+
+        $tag = $this->tag;
+
         return [
             'video_tag_id' => $this->id,
-            'name' => $this->whenLoaded('tag', fn () => $this->tag->name),
+            'name' => $tag->name,
             'id' => $this->tag_id,
         ];
     }

--- a/app/Http/Resources/VideoTagResource.php
+++ b/app/Http/Resources/VideoTagResource.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class VideoTagResource extends JsonResource {
-    protected static $tagCache = [];
+    // protected static $tagCache = [];
 
     /**
      * Transform the resource into an array.
@@ -14,18 +14,18 @@ class VideoTagResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        $tag_id = $this->tag_id;
+        // $tag_id = $this->tag_id;
 
-        if (isset(self::$tagCache[$tag_id])) {
-            $tag = self::$tagCache[$tag_id];
-        } else {
-            $tag = $this->tag;
-            self::$tagCache[$tag_id] = $tag;
-        }
+        // if (isset(self::$tagCache[$tag_id])) {
+        // $tag = self::$tagCache[$tag_id];
+        // } else {
+        // $tag = $this->tag;
+        // self::$tagCache[$tag_id] = $tag;
+        // }
 
         return [
             'video_tag_id' => $this->id,
-            'name' => $tag->name,
+            'name' => $this->whenLoaded('tag', fn() => $this->tag->name),
             'id' => $this->tag_id,
         ];
     }

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -284,8 +284,8 @@ class VerifyFiles implements ShouldQueue {
                 if (is_null($metadata->bitrate) && ! isset($changes['bitrate'])) {
                     $changes['bitrate'] = $audioMetadata['bitrate'] ?? null;
                 }
-
-                is_null($metadata->view_count) ? $changes['view_count'] = Record::where('video_id', $video->id)->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0) : $stored['view_count'] = $metadata->view_count;
+                $changes['view_count'] = Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0);
+                // is_null($metadata->view_count) ? $changes['view_count'] = Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0) : $stored['view_count'] = $metadata->view_count;
 
                 if (count($changes) > 0) {
                     $changes['date_scanned'] = date('Y-m-d h:i:s A');

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -215,7 +215,7 @@ class VerifyFiles implements ShouldQueue {
                     $changes['duration'] = $duration;
                 }
 
-                if (!str_starts_with($mime_type, 'audio') && (is_null($metadata->resolution_height) || is_null($metadata->frame_rate) || is_null($metadata->codec))) {
+                if (! str_starts_with($mime_type, 'audio') && (is_null($metadata->resolution_height) || is_null($metadata->frame_rate) || is_null($metadata->codec))) {
                     $this->confirmMetadata($filePath);
                     foreach ($this->fileMetaData['streams'] as $stream) {
                         if (! isset($stream['codec_type']) || $stream['codec_type'] !== 'video' || ! isset($stream['width'])) {
@@ -246,7 +246,7 @@ class VerifyFiles implements ShouldQueue {
                     $changes['season'] = count($season) == 1 ? (int) $season[0] : $audioMetadata['season'] ?? null;
                 }
 
-                if (is_null($metadata->title) && !str_starts_with($mime_type, 'audio')) {
+                if (is_null($metadata->title) && ! str_starts_with($mime_type, 'audio')) {
                     $newTitle = count($season) == 1 ? 'S' . $season[0] : '';
                     $newTitle .= count($episode) == 1 ? 'E' . $episode[0] : '';
 
@@ -277,11 +277,11 @@ class VerifyFiles implements ShouldQueue {
                     $changes['lyrics'] = $audioMetadata['lyrics'] ?? null;
                 }
 
-                if (is_null($metadata->codec) && !isset($changes['codec'])) {
+                if (is_null($metadata->codec) && ! isset($changes['codec'])) {
                     $changes['codec'] = $audioMetadata['codec'] ?? null;
                 }
 
-                if (is_null($metadata->bitrate) && !isset($changes['bitrate'])) {
+                if (is_null($metadata->bitrate) && ! isset($changes['bitrate'])) {
                     $changes['bitrate'] = $audioMetadata['bitrate'] ?? null;
                 }
 
@@ -454,7 +454,7 @@ class VerifyFiles implements ShouldQueue {
             break;
         }
 
-        if (isset($this->fileMetaData['format']['bit_rate']) && (!isset($results['bitrate']) || is_null($results['bitrate']))) {
+        if (isset($this->fileMetaData['format']['bit_rate']) && (! isset($results['bitrate']) || is_null($results['bitrate']))) {
             $results['bitrate'] = $this->fileMetaData['format']['bit_rate'];
         }
 

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -215,7 +215,7 @@ class VerifyFiles implements ShouldQueue {
                     $changes['duration'] = $duration;
                 }
 
-                if (! str_starts_with($mime_type, 'audio') && (is_null($metadata->resolution_height) || is_null($metadata->frame_rate) || is_null($metadata->codec))) {
+                if (! str_starts_with($mime_type, 'audio') && (is_null($metadata->resolution_height) || is_null($metadata->codec))) {
                     $this->confirmMetadata($filePath);
                     foreach ($this->fileMetaData['streams'] as $stream) {
                         if (! isset($stream['codec_type']) || $stream['codec_type'] !== 'video' || ! isset($stream['width'])) {

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -284,8 +284,7 @@ class VerifyFiles implements ShouldQueue {
                 if (is_null($metadata->bitrate) && ! isset($changes['bitrate'])) {
                     $changes['bitrate'] = $audioMetadata['bitrate'] ?? null;
                 }
-                $changes['view_count'] = Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0);
-                // is_null($metadata->view_count) ? $changes['view_count'] = Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0) : $stored['view_count'] = $metadata->view_count;
+                is_null($metadata->view_count) ? $changes['view_count'] = Record::where('video_id', $video->id)->whereNull('metadata_id')->count() + ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0) : $stored['view_count'] = $metadata->view_count;
 
                 if (count($changes) > 0) {
                     $changes['date_scanned'] = date('Y-m-d h:i:s A');

--- a/app/Jobs/VerifyFolders.php
+++ b/app/Jobs/VerifyFolders.php
@@ -93,9 +93,9 @@ class VerifyFolders implements ShouldQueue {
 
                 $stored = $series->toArray();
 
-                if (is_null($series->episodes)) {
-                    $changes['episodes'] = Video::where('folder_id', $folder->id)->count();
-                }
+                // if (is_null($series->episodes)) {
+                $changes['episodes'] = Video::where('folder_id', $folder->id)->count();
+                // }
 
                 if (is_null($series->title)) {
                     $changes['title'] = $folder->name;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -29,8 +29,8 @@ class Category extends Model {
 
     protected static function boot() {
         parent::boot(); // Automatic withCount
-        static::addGlobalScope('foldersCount', function ($builder) {
-            $builder->withCount('folders');
-        });
+        // static::addGlobalScope('foldersCount', function ($builder) {
+        //     $builder->withCount('folders');
+        // });
     }
 }

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -31,8 +31,8 @@ class Folder extends Model {
 
     protected static function boot() {
         parent::boot(); // Automatic withCount
-        static::addGlobalScope('videosCount', function ($builder) {
-            $builder->withCount('videos');
-        });
+        // static::addGlobalScope('videosCount', function ($builder) {
+        // $builder->withCount('videos');
+        // });
     }
 }

--- a/app/Models/Metadata.php
+++ b/app/Models/Metadata.php
@@ -56,6 +56,10 @@ class Metadata extends Model {
         return $this->hasMany(VideoTag::class);
     }
 
+    public function records(): HasMany {
+        return $this->hasMany(Record::class);
+    }
+
     public function getDateReleasedFormattedAttribute() {
         return $this->attributes['date_released'] ? Carbon::parse($this->attributes['date_released'])->format('F d, Y') : null;
     }

--- a/app/Models/Record.php
+++ b/app/Models/Record.php
@@ -19,10 +19,6 @@ class Record extends Model {
         return $this->belongsTo(User::class);
     }
 
-    public function video() {
-        return $this->belongsTo(Video::class);
-    }
-
     public function metadata() {
         return $this->belongsTo(Metadata::class);
     }

--- a/database/migrations/2025_02_04_204438_create_indexes_on_sorted_columns.php
+++ b/database/migrations/2025_02_04_204438_create_indexes_on_sorted_columns.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->index('is_private'); // Index for filtering
+        });
+        Schema::table('playbacks', function (Blueprint $table) {
+            $table->index('progress'); // Index for sorting
+        });
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->index('status'); // Index for filtering
+        });
+        Schema::table('sub_tasks', function (Blueprint $table) {
+            $table->index('status'); // Index for filtering
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropIndex(['is_private']);
+        });
+
+        Schema::table('playbacks', function (Blueprint $table) {
+            $table->dropIndex(['progress']);
+        });
+
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+        });
+
+        Schema::table('sub_tasks', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+        });
+    }
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
             - app-public:/var/www/html/public
             - ./docker/nginx/entrypoint.sh:/entrypoint.sh
         ports:
-            - '${APP_PORT}:${APP_PORT}'
+            - '${APP_PORT}:80'
         expose:
             - ${APP_PORT}
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,11 +86,13 @@ services:
             - app-public:/var/www/html/public
             - ./docker/nginx/entrypoint.sh:/entrypoint.sh
         ports:
-            - '8080:8080'
+            - '${APP_PORT}:${APP_PORT}'
         expose:
-            - '8080'
+            - ${APP_PORT}
         depends_on:
             - app
+        env_file:
+            - .env
         networks:
             - docker-network
     db:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,15 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+if [ -z "$APP_KEY" ] || [ "$APP_KEY" = "base64:" ]; then
+    echo "No APP_KEY detected, generating one..."
+    php artisan key:generate
+else
+    echo "APP_KEY already set, skipping key generation."
+fi
+
+php artisan reverb:generate
+
 echo "Waiting for PostgreSQL to be ready..."
 
 # Loop until PostgreSQL is ready

--- a/resources/js/components/cards/CategoryCard.vue
+++ b/resources/js/components/cards/CategoryCard.vue
@@ -179,8 +179,8 @@ watch(
 
                         <p class="">Folders: {{ data?.folders_count }}</p>
                     </span>
-                    <p class="hidden sm:block" :title="`Total Size ${formatFileSize(data.folders.reduce((total, folder) => total + Number(folder.total_size), 0))}`">
-                        {{ formatFileSize(data.folders.reduce((total, folder) => total + Number(folder.total_size), 0)) }}
+                    <p class="hidden sm:block" :title="`Total Size ${formatFileSize(data.total_size)}`">
+                        {{ formatFileSize(data.total_size) }}
                     </p>
                     <p class="sm:hidden">{{ defaultFolder ? `Default Folder: ${defaultFolder.name}` : 'No Default Folder' }}</p>
                 </span>
@@ -194,8 +194,8 @@ watch(
                     <p class="" :title="`Date Added ${data?.created_at ? toFormattedDate(new Date(data?.created_at + ' EST')) : 'N/A'}`">
                         {{ data?.created_at ? toFormattedDate(new Date(data?.created_at + ' EST')) : 'N/A' }}
                     </p>
-                    <p class="" :title="`Total Size ${formatFileSize(data.folders.reduce((total, folder) => total + Number(folder.total_size), 0))}`">
-                        {{ formatFileSize(data.folders.reduce((total, folder) => total + Number(folder.total_size), 0)) }}
+                    <p class="" :title="`Total Size ${formatFileSize(data.total_size)}`">
+                        {{ formatFileSize(data.total_size) }}
                     </p>
                 </span>
             </span>

--- a/resources/js/components/cards/VideoCard.vue
+++ b/resources/js/components/cards/VideoCard.vue
@@ -66,11 +66,11 @@ watch(
         "
     >
         <section class="flex justify-between gap-4 w-full items-center overflow-hidden group">
-            <HoverCard class="items-end" v-if="metaData?.fields.description" :hover-card-delay="400" :hover-card-leave-delay="300">
+            <HoverCard class="items-end" v-if="data.description" :hover-card-delay="400" :hover-card-leave-delay="300">
                 <template #trigger>
                     <span class="flex">
                         <h3 class="line-clamp-1">
-                            {{ metaData?.fields?.title }}
+                            {{ data.title }}
                             <!-- <span class="text-ellipsis text-wrap line-clamp-1 text-sm sm:text-base text-neutral-500 dark:text-neutral-400">{{
                     metaData?.fields?.description
                 }}</span> -->
@@ -79,11 +79,11 @@ watch(
                     </span>
                 </template>
                 <template #content>
-                    {{ metaData?.fields?.description }}
+                    {{ data.description }}
                 </template>
             </HoverCard>
             <h3 v-else class="w-full line-clamp-1 flex gap-8 items-end min-w-fit max-w-[30%]" title="Title">
-                {{ metaData?.fields?.title }}
+                {{ data.title }}
                 <!-- <span class="text-ellipsis text-wrap line-clamp-1 text-sm sm:text-base text-neutral-500 dark:text-neutral-400">{{
                     metaData?.fields?.description
                 }}</span> -->

--- a/resources/js/components/cards/VideoCard.vue
+++ b/resources/js/components/cards/VideoCard.vue
@@ -92,19 +92,17 @@ watch(
                 <h4 class="text-nowrap text-start truncate" :title="`File Size: ${data.file_size ? formatFileSize(data.file_size) : ''}`">
                     {{ data.file_size ? formatFileSize(data.file_size) : '' }}
                 </h4>
-                <h4 v-if="data.metadata?.codec || data.metadata?.resolution_height">|</h4>
                 <h4
-                    class="text-nowrap text-start truncate uppercase"
-                    :title="`File Size: ${data.file_size ? formatFileSize(data.file_size) : ''}`"
-                    v-if="data.metadata?.mime_type?.includes('audio') && data.metadata.codec"
+                    v-if="
+                        (data.metadata?.codec && data.metadata?.mime_type?.includes('audio')) || (!data.metadata?.mime_type?.includes('audio') && data.metadata?.resolution_height)
+                    "
                 >
+                    |
+                </h4>
+                <h4 class="text-nowrap text-start truncate uppercase" v-if="data.metadata?.mime_type?.includes('audio') && data.metadata.codec">
                     {{ data.metadata.codec }}
                 </h4>
-                <h4
-                    class="text-nowrap text-start truncate uppercase"
-                    :title="`File Size: ${data.file_size ? formatFileSize(data.file_size) : ''}`"
-                    v-else-if="data.metadata?.resolution_height"
-                >
+                <h4 class="text-nowrap text-start truncate uppercase" v-else-if="data.metadata?.resolution_height && !data.metadata?.mime_type?.includes('audio')">
                     {{ data.metadata.resolution_height }}P
                 </h4>
             </span>

--- a/resources/js/components/dashboard/DashboardLibraries.vue
+++ b/resources/js/components/dashboard/DashboardLibraries.vue
@@ -35,6 +35,16 @@ const sortingOptions = ref([
         value: 'folders_count',
         disabled: false,
     },
+    {
+        title: 'Videos',
+        value: 'videos_count',
+        disabled: false,
+    },
+    {
+        title: 'Size',
+        value: 'total_size',
+        disabled: false,
+    },
 ]);
 
 const { stateLibraries, isLoadingLibraries, stateLibraryId } = storeToRefs(useDashboardStore());

--- a/resources/js/components/panels/NavBar.vue
+++ b/resources/js/components/panels/NavBar.vue
@@ -43,7 +43,7 @@ watch(userData, handleAuthEvent, { immediate: false });
 
 <template>
     <nav id="navbar" class="flex py-1 gap-2 flex-wrap justify-between z-20">
-        <span class="flex items-end sm:items-center gap-2 justify-between w-full flex-1 min-w-fit">
+        <span class="flex items-end sm:items-center gap-2 justify-between w-full flex-1">
             <h1 id="title" class="text-2xl truncate capitalize">{{ pageTitle }}</h1>
             <section id="user-options" class="group inline-block relative shrink-0" data-dropdown-toggle="user-dropdown" aria-haspopup="true">
                 <DropdownMenu :dropdownOpen="showDropdown" @toggleDropdown="showDropdown = false">

--- a/resources/js/components/video/VideoInfoPanel.vue
+++ b/resources/js/components/video/VideoInfoPanel.vue
@@ -125,7 +125,7 @@ watch(
                 </h2>
                 <HoverCard :content="metaData?.fields?.description ?? defaultDescription" :hover-card-delay="800" :margin="10">
                     <template #trigger>
-                        <div :class="`h-[3.75rem] overflow-y-auto cursor-pointer dark:text-slate-400 text-slate-500 text-sm whitespace-pre-wrap scrollbar-minimal scrollbar-hover`">
+                        <div :class="`h-[3.75rem] overflow-y-auto dark:text-slate-400 text-slate-500 text-sm whitespace-pre-wrap scrollbar-minimal scrollbar-hover`">
                             {{ metaData?.fields?.description ?? defaultDescription }}
                         </div>
                     </template>

--- a/resources/js/stores/ContentStore.js
+++ b/resources/js/stores/ContentStore.js
@@ -65,7 +65,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueA = videoA[videoSort.value.column];
             let valueB = videoB[videoSort.value.column];
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * videoSort.value.dir;
-            return `${valueA?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`) * videoSort.value.dir;
+            return `${valueA}`?.toLowerCase().replaceAll(/\s+/g, ' ')?.localeCompare(`${valueB}`?.toLowerCase().replaceAll(/\s+/g, ' ')) * videoSort.value.dir;
         });
 
         return sortedList;
@@ -85,7 +85,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueB = column === 'folder_name' ? recordB.relationships?.folder?.name : recordB.relationships[column];
 
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * dir;
-            return `${valueA?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`) * dir;
+            return `${valueA}`?.toLowerCase().replaceAll(/\s+/g, ' ')?.localeCompare(`${valueB}`?.toLowerCase().replaceAll(/\s+/g, ' ')) * dir;
         });
         stateRecords.value = tempList;
         return tempList;

--- a/resources/js/stores/ContentStore.js
+++ b/resources/js/stores/ContentStore.js
@@ -65,7 +65,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueA = videoA[videoSort.value.column];
             let valueB = videoB[videoSort.value.column];
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * videoSort.value.dir;
-            return `${valueA.toLowerCase().replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB.toLowerCase().replaceAll(/\s+/g, ' ')}`) * videoSort.value.dir;
+            return `${valueA?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`) * videoSort.value.dir;
         });
 
         return sortedList;
@@ -85,7 +85,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueB = column === 'folder_name' ? recordB.relationships?.folder?.name : recordB.relationships[column];
 
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * dir;
-            return `${valueA.toLowerCase().replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB.toLowerCase().replaceAll(/\s+/g, ' ')}`) * dir;
+            return `${valueA?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB?.toLowerCase()?.replaceAll(/\s+/g, ' ')}`) * dir;
         });
         stateRecords.value = tempList;
         return tempList;

--- a/resources/js/stores/ContentStore.js
+++ b/resources/js/stores/ContentStore.js
@@ -65,7 +65,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueA = videoA[videoSort.value.column];
             let valueB = videoB[videoSort.value.column];
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * videoSort.value.dir;
-            return `${valueA.toLowerCase()}`?.localeCompare(`${valueB.toLowerCase()}`) * videoSort.value.dir;
+            return `${valueA.toLowerCase().replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB.toLowerCase().replaceAll(/\s+/g, ' ')}`) * videoSort.value.dir;
         });
 
         return sortedList;
@@ -85,7 +85,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueB = column === 'folder_name' ? recordB.relationships?.folder?.name : recordB.relationships[column];
 
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * dir;
-            return `${valueA}`?.localeCompare(`${valueB}`) * dir;
+            return `${valueA.toLowerCase().replaceAll(/\s+/g, ' ')}`?.localeCompare(`${valueB.toLowerCase().replaceAll(/\s+/g, ' ')}`) * dir;
         });
         stateRecords.value = tempList;
         return tempList;

--- a/resources/js/stores/ContentStore.js
+++ b/resources/js/stores/ContentStore.js
@@ -65,7 +65,7 @@ export const useContentStore = defineStore('Content', () => {
             let valueA = videoA[videoSort.value.column];
             let valueB = videoB[videoSort.value.column];
             if (valueA && valueB && typeof valueA === 'number' && typeof valueB === 'number') return (valueA - valueB) * videoSort.value.dir;
-            return `${valueA}`?.localeCompare(`${valueB}`) * videoSort.value.dir;
+            return `${valueA.toLowerCase()}`?.localeCompare(`${valueB.toLowerCase()}`) * videoSort.value.dir;
         });
 
         return sortedList;

--- a/resources/js/stores/DashboardStore.ts
+++ b/resources/js/stores/DashboardStore.ts
@@ -30,10 +30,7 @@ export const useDashboardStore = defineStore('Dashboard', () => {
         stateLibraries.value = v?.data ?? [];
 
         if (!v?.data) return;
-        let totalSize = v.data.reduce(
-            (total: number, library: CategoryResource) => total + library.folders.reduce((total: number, folder: FolderResource) => total + Number(folder.total_size), 0),
-            0,
-        );
+        let totalSize = v.data.reduce((total: number, library: CategoryResource) => total + library.total_size, 0);
 
         if (!isNaN(totalSize)) stateTotalLibrariesSize.value = formatFileSize(totalSize);
     });

--- a/resources/js/types/resources.ts
+++ b/resources/js/types/resources.ts
@@ -15,6 +15,7 @@ export interface CategoryResource {
     folders: FolderResource[];
     folders_count: number;
     videos_count?: number;
+    total_size: number;
     default_folder_id?: number;
     created_at?: string;
     last_scan: number;


### PR DESCRIPTION
## v0.1.14 General Update

### Fixes
- Docker build file no longer generates keys. Operation moved to entrypoint. Still regenerates laravel key on each start. Fixes #93
- Verify Files task ommited some fields and caused infinite re-runs on new files
- Watch request was resetting view counts due to incorrect syntax
- Fix nginx using port 80 even if the app runs on another port in docker
- Fix navbar going off screen
- Reduce db queries when loading video tags for a large number of videos (300+)
- Reduce usage of UseCount and instead use generated episode counts
- Fix some mimetypes set to application/* instead of audio/mpeg
- Fix tag names not returned with video upon edit

### Changes
- Reverb Generate command only changes keys if they don't all exist already
- Video and record sorting ignores case and multiple spaces

### Additions
- User customisable domain and ports for docker container with simplified env file