### PR TITLE
fix: database connection timezone is not guaranteed

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -96,7 +96,6 @@ return [
             'search_path' => 'public',
             'sslmode' => 'prefer',
             'timezone' => 'UTC',
-            // 'timezone' => '+00:00',
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
### Fixes

- Postgres connection could be in local system timezone regardless of the configured server timezone, breaking timestamp values and causing drift

### Changes

- Enforces postgres connection to be in UTC

