### PR TITLE
Feat/cached metadata

### DIFF
--- a/app/Jobs/IndexFiles.php
+++ b/app/Jobs/IndexFiles.php
@@ -216,6 +216,8 @@ class IndexFiles extends ManagedSubTask {
                 'resolution_width',
                 'resolution_height',
                 'frame_rate',
+                // Fills once
+                'raw_metadata',
             ]);
 
             // One day logging should be put in the database
@@ -509,6 +511,8 @@ class IndexFiles extends ManagedSubTask {
                     'media_type' => $media_type,
                     'mime_type' => $mime_type,
                     'duration' => $duration,
+
+                    'raw_metadata' => $fileMetaData,
                 ];
             }
         }
@@ -558,16 +562,18 @@ class IndexFiles extends ManagedSubTask {
                 'cleanName' => $cleanName,
                 'key' => $key,
 
-                'media_type' => $media_type,
-                'mime_type' => $mime_type,
+                'media_type' => $mediaType,
+                'mime_type' => $mimeType,
                 'duration' => $duration,
 
+                'raw_metadata' => $rawMetadata
             ] = $file;
 
             ['uuid' => $uuid, 'willEmbedUuid' => $willEmbedUuid, 'willReplaceMissing' => $willReplaceMissing] = $this->resolveExistingUuid($embeddedUuid, $compositeId, $logicalCompositeId, $deletedVideoIds, $metadataByUuid, $metadataByComposite);
 
             if ($willEmbedUuid) {
                 $this->embedChain[] = new EmbedUidInMetadata($absolutePath, $uuid, $this->taskId, $currentID); // TODO: Make tagging user configurable, probably by library but always use a uuid
+                $rawMetadata['tags']['uuid'] = $uuid; // Backfill uuid into cached metadata if it did not exist at time of probe
             }
 
             // Dont add uuid to video if embedding job is to be scheduled. This prevents not knowing if the uuid was applied to the video in case a job fails.
@@ -589,8 +595,8 @@ class IndexFiles extends ManagedSubTask {
                 'uuid' => $uuid,
                 'file_size' => filesize($rawFile),
                 'duration' => $duration,
-                'mime_type' => $mime_type ?? null,
-                'media_type' => $media_type,
+                'mime_type' => $mimeType ?? null,
+                'media_type' => $mediaType,
                 'file_scanned_at' => now(),
                 'file_modified_at' => Carbon::createFromTimestampUTC(min($mtime, $ctime)),
                 'subtitles_scanned_at' => null, // Reset covers new files and replaced files
@@ -599,6 +605,7 @@ class IndexFiles extends ManagedSubTask {
                 'resolution_width' => null,
                 'resolution_height' => null,
                 'frame_rate' => null,
+                'raw_metadata' => json_encode($rawMetadata),
             ];
             $current[$key] = $currentID;    // add to current
             $changes[] = $generated;        // add to new (insert)

--- a/app/Jobs/IndexFiles.php
+++ b/app/Jobs/IndexFiles.php
@@ -81,7 +81,7 @@ class IndexFiles extends ManagedSubTask {
 
         $directories = $this->generateCategories($mediaRoot);
         $subDirectories = $this->generateFolders($path, $directories['data']['categoryStructure']);
-        $files = $this->generateVideos($path, $subDirectories['data']['folderStructure'], $directories['data']['categoryStructure']);
+        $files = $this->generateVideos($path, $subDirectories['data']['folderStructure']);
 
         if (isset($files['updatedFolderStructure'])) {
             $subDirectories['data']['folderStructure'] = $files['updatedFolderStructure'];

--- a/app/Jobs/Utility/Subtitles/ScanSubtitles.php
+++ b/app/Jobs/Utility/Subtitles/ScanSubtitles.php
@@ -113,7 +113,7 @@ class ScanSubtitles extends ManagedSubTask {
             // Embedded Subtitles - scanned only if file was updated
             if ($fileUpdated) {
                 // TODO: Cache this output from index or subsequent verify jobs as json in the model and never call from here
-                $fileMetaData = VerifyFiles::getFileMetadata($filePath, 'Subtitle Scan');
+                $fileMetaData = $this->verifyMetadata($metadata, $filePath);
                 $subtitleTransactions = $subtitleScanner->scanEmbeddedSubtitles($uuid, $fileMetaData);
             }
 
@@ -148,5 +148,20 @@ class ScanSubtitles extends ManagedSubTask {
         } catch (\Throwable $th) {
             $this->handleError('Error inserting subtitle tracks', $th, $scannedUuids, count($batchTransactions));
         }
+    }
+
+    private function verifyMetadata($metadata, $filePath): array {
+        $raw_metadata = $metadata->raw_metadata;
+
+        if (empty($raw_metadata)) {
+            Log::error('raw_metadata missing for updated file in ScanSubtitles', [
+                'uuid' => $metadata->uuid,
+                'title' => $metadata->title,
+                'file_path' => $filePath,
+            ]);
+            $raw_metadata = VerifyFiles::getFileMetadata($filePath, 'Subtitle Scan'); // fallback but don't update metadata due to separation of concerns?
+        }
+
+        return $raw_metadata;
     }
 }

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -497,7 +497,7 @@ class VerifyFiles extends ManagedSubTask {
             $results = array_merge($results, array_filter([
                 'codec' => $stream['codec_name'] ?? null,
                 'bitrate' => $stream['bit_rate'] ?? null,
-            ], fn($value) => !is_null($value)));
+            ], fn ($value) => ! is_null($value)));
             break;
         }
 

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -184,8 +184,8 @@ class VerifyFiles extends ManagedSubTask {
                 if ($stored['media_type'] !== $media_type) {
                     $changes['media_type'] = $media_type;
                 }
-                // if file is of type audio and one of the following is true: artist is null, album is null, codec is null, bitrate is null => generate description from audio tags
-                $audioMetadata = ($fileUpdated || is_null($metadata->artist) || is_null($metadata->album) || is_null($metadata->bitrate) || is_null($metadata->codec)) && $is_audio ? $this->getAudioDescription($filePath, $this->fileMetaData ?? null) : [];
+                // if file is of type audio and one of the following is true: artist is null, album is null, codec is null => generate description from audio tags
+                $audioMetadata = ($fileUpdated || is_null($metadata->artist) || is_null($metadata->album) || is_null($metadata->codec)) && $is_audio ? $this->getAudioDescription($filePath, $this->fileMetaData ?? null) : [];
 
                 // TODO: if no poster_url is set or file was modified since last update and the file is of type audio, extract image
                 // TODO: if poster_url is set and it is not a local url, download and save as local image

--- a/app/Jobs/VerifyFiles.php
+++ b/app/Jobs/VerifyFiles.php
@@ -97,6 +97,9 @@ class VerifyFiles extends ManagedSubTask {
 
         try {
             foreach ($this->videos as $video) {
+                // Clear job cache on every loop
+                $this->fileMetaData = [];
+
                 $baseName = basename($video->path);
                 $compositeId = $video->folder->path . '/' . $baseName;
 
@@ -111,13 +114,11 @@ class VerifyFiles extends ManagedSubTask {
                     throw new \Exception("File media/{$video->folder->path}/{$baseName} no longer exists. Index your videos before running this task again.");
                 }
 
-                // enforce loading file metadata if uuid is missing
-                $this->fileMetaData = is_null($video->uuid) ? $this->getFileMetadata($filePath, 'uuid missing') : [];
-                $uuid = $video->uuid ?? '';
+                $uuid = $video->uuid;
 
                 // handle missing or invalid Uuid
-                if (! Uuid::isValid($uuid)) {
-                    $uuid = $this->resolveMediaUuid($video, $filePath);
+                if (! Uuid::isValid($uuid ?? '')) {
+                    $uuid = $this->resolveMediaUuid($video, $filePath); // Calls confirm metadata and will always lead to an ffprobe call
                 }
 
                 /**
@@ -128,12 +129,23 @@ class VerifyFiles extends ManagedSubTask {
 
                 if (! $metadata) {
                     $metadata = Metadata::create(['uuid' => $uuid, 'composite_id' => $compositeId, 'video_id' => $video->id]);
+                    $metadata->refresh();
                 }
 
                 $stored = $metadata->toArray(); // Metadata from db
                 $changes = []; // Changes -> stored + changes . length has to be the same for every video so must generate defaults
 
+                if (isset($stored['raw_metadata']) && is_array($stored['raw_metadata'])) {
+                    $stored['raw_metadata'] = json_encode($stored['raw_metadata']); // must re-encode stored metadata cache
+                }
+
                 $fileUpdated = $metadata->file_scanned_at && filemtime($filePath) > $metadata->file_scanned_at->timestamp;
+                $this->fileMetaData = $metadata->raw_metadata; // populate with potential cached metadata as a base value. If the base is insufficient, confirmMetadata should handle extraction on its own
+
+                if ($fileUpdated) { // if file was updated, force load raw data and save to db
+                    $this->fileMetaData = $this->getFileMetadata($filePath, 'file updated');
+                    $changes['raw_metadata'] = json_encode($this->fileMetaData);
+                }
 
                 if (is_null($metadata->uuid) || $fileUpdated) {
                     $changes['uuid'] = $uuid;
@@ -306,6 +318,10 @@ class VerifyFiles extends ManagedSubTask {
                     $changes['view_count'] = ($metadata->id ? Record::where('metadata_id', $metadata->id)->count() : 0);
                 }
 
+                if (! $fileUpdated && ! empty($this->fileMetaData) && empty($metadata->raw_metadata)) { // if file wasnt updated but the db cached value was empty and a local cache was loaded, save to db
+                    $changes['raw_metadata'] = json_encode($this->fileMetaData);
+                }
+
                 if (! empty($changes)) {
                     $changes['file_scanned_at'] = now();
 
@@ -368,6 +384,7 @@ class VerifyFiles extends ManagedSubTask {
                     'first_file_modified_at',
                     'media_type',
                     'subtitles_scanned_at',
+                    'raw_metadata',
                 ]
             );
 
@@ -442,9 +459,10 @@ class VerifyFiles extends ManagedSubTask {
 
     // Call get metadata when needed
     private function confirmMetadata(string $filePath, string $reason = 'und') {
-        if (is_null($this->fileMetaData) || count($this->fileMetaData) == 0) {
-            $this->fileMetaData = $this->getFileMetadata($filePath, $reason);
+        if (! empty($this->fileMetaData)) {
+            return;
         }
+        $this->fileMetaData = $this->getFileMetadata($filePath, $reason);
     }
 
     private function getAudioDescription($filePath) {
@@ -472,19 +490,19 @@ class VerifyFiles extends ManagedSubTask {
         ];
 
         foreach ($streams as $stream) {
-            if (! $stream['codec_type'] == 'audio') {
+            if ($stream['codec_type'] != 'audio') {
                 continue;
             }
 
             $results = array_merge($results, array_filter([
                 'codec' => $stream['codec_name'] ?? null,
                 'bitrate' => $stream['bit_rate'] ?? null,
-            ]));
+            ], fn($value) => !is_null($value)));
             break;
         }
 
         if (isset($this->fileMetaData['format']['bit_rate']) && (! isset($results['bitrate']) || is_null($results['bitrate']))) {
-            $results['bitrate'] = $this->fileMetaData['format']['bit_rate'];
+            // This is inaccurate $results['bitrate'] = $this->fileMetaData['format']['bit_rate'];
         }
 
         return $results;
@@ -589,8 +607,10 @@ class VerifyFiles extends ManagedSubTask {
 
     protected function resolveMediaUuid($media, $filePath) {
         // if the media in db or file does not have a valid uuid, it will add it in both the db and on the file.
+        $this->confirmMetadata($filePath, 'resolve uuid');
         if (! isset($this->fileMetaData['tags']['uuid'])) {
             $uuid = Str::uuid()->toString();
+            $this->fileMetaData['tags']['uuid'] = $uuid;
             $this->embedChain[] = new EmbedUidInMetadata($filePath, $uuid, $this->taskId, $media->id);
         } else {
             $uuid = $this->fileMetaData['tags']['uuid'];

--- a/app/Models/Metadata.php
+++ b/app/Models/Metadata.php
@@ -59,6 +59,8 @@ class Metadata extends Model {
      * intro_duration       -> float(2) (nullable)
      *
      * first_file_modified_at     -> timestamptz (nullable)
+     *
+     * raw_metadata         -> jsonb (nullable)
      */
     protected $fillable = [
         // Id
@@ -92,6 +94,7 @@ class Metadata extends Model {
         'resolution_height',
         'frame_rate',
         'media_type',
+        'raw_metadata',
 
         // API Editable
         'view_count',
@@ -116,6 +119,8 @@ class Metadata extends Model {
 
         'intro_start' => 'float',
         'intro_duration' => 'float',
+
+        'raw_metadata' => 'array',
     ];
 
     public function video(): BelongsTo {

--- a/app/Services/Subtitles/SubtitleManager.php
+++ b/app/Services/Subtitles/SubtitleManager.php
@@ -40,7 +40,7 @@ class SubtitleManager {
 
     private function deleteSubtitleFiles(Metadata $metadata): void {
         $directory = SubtitlePath::buildDirectory($metadata->uuid);
-        Log::info('Cleared Subtitle Directory', ['uuid' => $metadata->uuid, 'title' => $metadata->title, 'dir' => $directory]);
+        Log::info('Cleared Subtitle Directory ' . $metadata->uuid, ['uuid' => $metadata->uuid, 'title' => $metadata->title, 'dir' => $directory]);
         Storage::disk('local')->deleteDirectory($directory);
     }
 }

--- a/app/Services/Subtitles/SubtitleResolver.php
+++ b/app/Services/Subtitles/SubtitleResolver.php
@@ -51,7 +51,7 @@ class SubtitleResolver {
             $subtitle->refresh();
             $convertedPath = $this->formatter->convert($subtitle->path, $requestedPath, $format);
 
-            Log::info('Subtitle resolved (generated)', [
+            Log::info('Subtitle resolved (generated) ' . $metadata->uuid, [
                 'metadata_uuid' => $metadata->uuid,
                 'track' => $track,
                 'format' => $format,
@@ -61,7 +61,7 @@ class SubtitleResolver {
 
             return Response::file($convertedPath);
         } catch (\Throwable $th) {
-            Log::error('Subtitle Resolver Failed', [
+            Log::error('Subtitle Resolver Failed ' . $metadata->uuid, [
                 'error' => $th->getMessage(),
                 'metadata_uuid' => $metadata->uuid ?? null,
                 'track' => $track,

--- a/database/migrations/2026_03_31_015208_add_cached_metadata_to_metadata.php
+++ b/database/migrations/2026_03_31_015208_add_cached_metadata_to_metadata.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('metadata', function (Blueprint $table) {
+            $table->jsonb('raw_metadata')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('metadata', function (Blueprint $table) {
+            $table->dropColumn('raw_metadata');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5788,9 +5788,9 @@
             }
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "license": "MIT"
         },
         "node_modules/lodash.clonedeep": {

--- a/resources/js/components/cards/data/FolderCard.vue
+++ b/resources/js/components/cards/data/FolderCard.vue
@@ -133,7 +133,7 @@ const mediaType = computed(() => {
                             <h4 class="w-full flex-1 truncate text-wrap sm:text-nowrap" :title="`${data.file_count} ${mediaType}${data.file_count !== 1 ? 's' : ''}`">
                                 {{ data.file_count }} {{ mediaType }}{{ data.file_count !== 1 ? 's' : '' }}
                             </h4>
-                            <h4 class="w-fit truncate text-nowrap sm:text-right lg:hidden xl:block">
+                            <h4 class="w-fit truncate text-nowrap sm:text-right">
                                 {{ formatFileSize(data.total_size ?? 0) }}
                             </h4>
                         </section>

--- a/resources/js/components/cards/data/RecordCardDetails.vue
+++ b/resources/js/components/cards/data/RecordCardDetails.vue
@@ -3,6 +3,7 @@ import type { RecordResource } from '@/types/resources';
 
 import { ButtonCorner } from '@/components/cedar-ui/button';
 import { toTimeSpan } from '@/service/util';
+import { RouterLink } from 'vue-router';
 import { computed } from 'vue';
 
 import CircumPlay1 from '~icons/circum/play-1';
@@ -21,23 +22,30 @@ const videoLink = computed(() => {
 </script>
 
 <template>
-    <section :class="['data-card', 'group relative flex w-full cursor-pointer flex-col flex-wrap gap-4 rounded-xl p-3 text-left shadow-sm ring-1 ring-gray-900/5 sm:flex-row']">
-        <RouterLink v-if="videoLink" :to="videoLink" class="absolute top-0 left-0 h-full w-full rounded-xl" title="Watch Video" />
-
-        <header class="flex w-full justify-between gap-4">
-            <h2 class="z-10 flex items-center truncate" :title="data.file_name">
-                {{ data.video_name ?? `[Deleted] ${data.file_name}` }}
-            </h2>
+    <section :class="['data-card', 'group relative flex w-full flex-col flex-wrap gap-4 rounded-xl p-3 text-left shadow-sm ring-1 ring-gray-900/5 sm:flex-row']">
+        <header class="flex w-full items-center justify-between gap-4">
+            <component
+                :is="videoLink ? RouterLink : 'div'"
+                :class="['hover:text-primary dark:hover:text-primary-muted h-fit flex-1 overflow-hidden', { 'cursor-pointer': videoLink }]"
+                :to="videoLink"
+            >
+                <h2 class="z-10 truncate" :title="`Go to ${data.file_name}`">
+                    <template v-if="!data.video_id">
+                        {{ '[Deleted] ' }}
+                    </template>
+                    {{ data.video_name ?? data.file_name }}
+                </h2>
+            </component>
             <div class="z-10 flex cursor-auto justify-end gap-1" @click.stop.prevent="">
                 <ButtonCorner
                     v-if="videoLink"
                     :useDefaultStyle="false"
                     :to="videoLink"
-                    :label="'Watch Video'"
+                    :label="'Play Media'"
                     class="hover:text-primary dark:hover:text-primary-muted hover:dark:bg-surface-1 hover:bg-surface-6 size-7 transition-none"
                 >
                     <template #icon>
-                        <CircumPlay1 width="20" height="20" />
+                        <CircumPlay1 width="20" height="20" class="ms-0.5" />
                     </template>
                 </ButtonCorner>
                 <ButtonCorner

--- a/resources/js/components/cedar-ui/table/TableBase.vue
+++ b/resources/js/components/cedar-ui/table/TableBase.vue
@@ -98,7 +98,7 @@ onMounted(() => {
                 </ButtonIcon>
             </div>
         </section>
-        <section :class="cn(useGrid || 'flex w-full flex-wrap gap-2', tableStyles)">
+        <section :class="cn(useGrid || 'flex w-full flex-1 flex-col flex-wrap gap-2', tableStyles)">
             <TableLoadingSpinner v-if="loading || pageData?.length === 0" :is-loading="loading" :data-length="pageData?.length" :no-results-message="noResultsMessage" />
             <template v-else>
                 <template v-for="(row, index) in pageData" :key="row.id">

--- a/resources/js/components/video/VideoInfoPanel.vue
+++ b/resources/js/components/video/VideoInfoPanel.vue
@@ -110,7 +110,10 @@ const handleEdit = () => {
 };
 
 const handleResetSubtitles = () => {
-    if (!stateVideo.value.metadata?.id) return;
+    if (!stateVideo.value.metadata?.id) {
+        toast.error('ID Missing');
+        return;
+    }
     toast.promise(resetSubtitles(stateVideo.value.metadata.id), {
         loading: 'Resetting Subtitles',
         loadingDescription: `Clearing subtitle cache`,

--- a/resources/js/views/HistoryView.vue
+++ b/resources/js/views/HistoryView.vue
@@ -93,8 +93,9 @@ onMounted(() => {
 <template>
     <LayoutBase>
         <template v-slot:content>
-            <section id="content-history" class="3xl:min-h-[60vh] space-y-2 lg:min-h-[80vh]">
+            <section id="content-history" class="3xl:min-h-[60vh] flex flex-col space-y-2 lg:min-h-[80vh]">
                 <TableBase
+                    :class="'flex-1'"
                     :data="filteredRecords"
                     :row="RecordCardDetails"
                     :clickAction="handleDelete"

--- a/resources/js/views/VideoView.vue
+++ b/resources/js/views/VideoView.vue
@@ -169,19 +169,19 @@ const setFolderAsPageTitle = () => {
     pageTitle.value = title;
 };
 
-const setVideoAsDocumentTitle = () => {
-    const folderTitle = stateFolder.value.series?.title ?? stateFolder.value.name;
-    const videoTitle = stateVideo.value?.metadata?.title ?? stateVideo.value?.name;
-    if (!folderTitle || !videoTitle) return;
-    document.title = `${folderTitle} · ${videoTitle}`;
+const setVideoAsDocumentTitle = async () => {
+    const folderTitle = stateFolder.value.series?.title || stateFolder.value.name;
+    const videoTitle = stateVideo.value?.metadata?.title || stateVideo.value?.name;
+    if (!folderTitle) return;
+    document.title = videoTitle ? `${folderTitle} · ${videoTitle}` : folderTitle;
 };
 
 //#endregion
 
 onMounted(async () => {
-    reload();
-
     selectedSideBar.value = '';
+    await reload();
+    setVideoAsDocumentTitle(); // Load folder and potential media data before setting first title
 });
 
 watch(
@@ -189,7 +189,7 @@ watch(
     (id) => {
         if (stateFolder.value.name !== route.params.folder) return;
 
-        if (!playlistFind(id)) return;
+        playlistFind(id);
 
         setVideoAsDocumentTitle();
     },
@@ -205,7 +205,7 @@ watch(
 );
 watch(() => selectedSideBar.value, cycleSideBar, { immediate: false });
 watch(() => stateFolder.value, setFolderAsPageTitle);
-watch(() => stateVideo.value, setVideoAsDocumentTitle, { immediate: true });
+watch(() => stateVideo.value, setVideoAsDocumentTitle, { immediate: false });
 </script>
 
 <template>


### PR DESCRIPTION
### Fixes

- Audio files are always re-scanned for a bitrate even if the value does not exist (ex/ FLAC)
- History page cls and malformed card click areas
- Tab title is never set if you navigate to a valid folder with no media content

### Changes

- Cache raw ffprobe output in metadata table to reduce scan times
- Increased individual metadata related logging verbosity to make entries searchable in log-viewer by uuid