### PR TITLE
Feat/downloads

### DIFF
--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -107,11 +107,11 @@ class CategoryController extends Controller {
         }
 
         $validated = $request->validate([
-            'allow_downloads' => 'sometimes|boolean',
-            'require_login_for_downloads' => 'sometimes|boolean',
+            'downloads_enabled' => 'sometimes|boolean',
+            'downloads_require_auth' => 'sometimes|boolean',
         ]);
         $category->update($validated);
 
-        return response($category->only(['allow_downloads', 'require_login_for_downloads']));
+        return response($category->only(['downloads_enabled', 'downloads_require_auth']));
     }
 }

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -10,6 +10,7 @@ use App\Models\Category;
 use App\Models\Folder;
 use App\Traits\HasModelHelpers;
 use App\Traits\HttpResponses;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class CategoryController extends Controller {
@@ -82,7 +83,7 @@ class CategoryController extends Controller {
      *
      * @param  int  $category_id
      */
-    public function updatePrivacy(CategoryPrivacyUpdateRequest $request, Category $category) {
+    public function updatePrivacySettings(CategoryPrivacyUpdateRequest $request, Category $category) {
         if (Auth::id() !== 1) {
             return $this->forbidden();
         }
@@ -93,5 +94,24 @@ class CategoryController extends Controller {
         $category->save();
 
         return $this->success($validated);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  int  $category_id
+     */
+    public function updateDownloadSettings(Request $request, Category $category) {
+        if (Auth::id() !== 1) {
+            return $this->forbidden();
+        }
+
+        $validated = $request->validate([
+            'allow_downloads' => 'sometimes|boolean',
+            'require_login_for_downloads' => 'sometimes|boolean',
+        ]);
+        $category->update($validated);
+
+        return response($category->only(['allow_downloads', 'require_login_for_downloads']));
     }
 }

--- a/app/Http/Controllers/Api/V1/Media/MediaController.php
+++ b/app/Http/Controllers/Api/V1/Media/MediaController.php
@@ -15,16 +15,15 @@ class MediaController extends Controller {
 
     public function download(Video $video) {
         if (! $video->downloadsEnabled() || (Auth::id() === null && $video->folder->category->downloads_require_auth)) {
-            $this->logDownloadAttempt('blocked', [
-                'id' => $video->id,
-                'file_path' => $video->path,
-                'reason' => 'permission_denied',
-            ]);
+            $this->logDownloadAttempt($video, 'blocked', ['reason' => 'Permission denied.']);
             abort(403);
         }
 
         $path = substr($video->path, 7); // relative path from public disk
-        abort_unless(Storage::disk('public')->exists($path), 404);
+        if (! Storage::disk('public')->exists($path)) {
+            $this->logDownloadAttempt($video, 'blocked', ['reason' => 'File does not exist.']);
+            abort(404);
+        }
 
         $absolutePath = Storage::disk('public')->path($path);
 
@@ -32,24 +31,14 @@ class MediaController extends Controller {
         $maxSize = $maxSizeMB * 1024 * 1024;
 
         $fileSize = filesize($absolutePath);
+        $fileSizeMB = round($fileSize / (1024 * 1024), 2);
 
         if ($fileSize > $maxSize) {
-            $fileSizeMB = round($fileSize / (1024 * 1024), 2);
-
-            $this->logDownloadAttempt('blocked', [
-                'id' => $video->id,
-                'file_path' => $video->path,
-                'reason' => "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.",
-            ]);
-
-            abort(400, "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.");
+            $this->logDownloadAttempt($video, 'blocked', ['reason' => "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB."]);
+            abort(403, "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.");
         }
 
-        $this->logDownloadAttempt('success', [
-            'id' => $video->id,
-            'file_path' => $video->path,
-            'file_size_mb' => round($fileSize / (1024 * 1024), 2),
-        ]);
+        $this->logDownloadAttempt($video, 'success', ['file_size_mb' => round($fileSizeMB)]);
 
         return response()->download($absolutePath, basename($absolutePath), [
             'Content-Length' => $fileSize,

--- a/app/Http/Controllers/Api/V1/Media/MediaController.php
+++ b/app/Http/Controllers/Api/V1/Media/MediaController.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Storage;
 
 class MediaController extends Controller {
     public function download(Video $video) {
-        if (! $video->downloadsEnabled() || (Auth::id() === null && $video->folder->category->require_login_for_downloads)) {
+        if (! $video->downloadsEnabled() || (Auth::id() === null && $video->folder->category->downloads_require_auth)) {
             abort(403);
         }
 

--- a/app/Http/Controllers/Api/V1/Media/MediaController.php
+++ b/app/Http/Controllers/Api/V1/Media/MediaController.php
@@ -4,14 +4,22 @@ namespace App\Http\Controllers\Api\V1\Media;
 
 use App\Http\Controllers\Controller;
 use App\Models\Video;
+use App\Traits\LogsDownloads;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class MediaController extends Controller {
+    use LogsDownloads;
+
     public function download(Video $video) {
         if (! $video->downloadsEnabled() || (Auth::id() === null && $video->folder->category->downloads_require_auth)) {
+            $this->logDownloadAttempt('blocked', [
+                'id' => $video->id,
+                'file_path' => $video->path,
+                'reason' => 'permission_denied',
+            ]);
             abort(403);
         }
 
@@ -27,8 +35,21 @@ class MediaController extends Controller {
 
         if ($fileSize > $maxSize) {
             $fileSizeMB = round($fileSize / (1024 * 1024), 2);
+
+            $this->logDownloadAttempt('blocked', [
+                'id' => $video->id,
+                'file_path' => $video->path,
+                'reason' => "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.",
+            ]);
+
             abort(400, "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.");
         }
+
+        $this->logDownloadAttempt('success', [
+            'id' => $video->id,
+            'file_path' => $video->path,
+            'file_size_mb' => round($fileSize / (1024 * 1024), 2),
+        ]);
 
         return response()->download($absolutePath, basename($absolutePath), [
             'Content-Length' => $fileSize,

--- a/app/Http/Controllers/Api/V1/Media/MediaController.php
+++ b/app/Http/Controllers/Api/V1/Media/MediaController.php
@@ -1,13 +1,40 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1\Media;
 
+use App\Http\Controllers\Controller;
+use App\Models\Video;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 
 class MediaController extends Controller {
+    public function download(Video $video) {
+        if (Auth::id() === null) {
+            abort(403, 'Forbidden Action');
+        }
+
+        $path = substr($video->path, 7); // relative path from public disk
+        abort_unless(Storage::disk('public')->exists($path), 404);
+
+        $absolutePath = Storage::disk('public')->path($path);
+
+        $maxSizeMB = config('media.downloads.max_size_mb', 4096);
+        $maxSize = $maxSizeMB * 1024 * 1024;
+
+        $fileSize = filesize($absolutePath);
+
+        if ($fileSize > $maxSize) {
+            $fileSizeMB = round($fileSize / (1024 * 1024), 2);
+            abort(400, "File too large: {$fileSizeMB}MB. Maximum allowed download is {$maxSizeMB}MB.");
+        }
+
+        return response()->download($absolutePath, basename($absolutePath), [
+            'Content-Length' => $fileSize,
+        ]);
+    }
+
     public function show(Request $request, $path) {
         Log::info('Request path: ' . $path);
         Log::info('Request full URL: ' . $request->fullUrl());

--- a/app/Http/Controllers/Api/V1/Media/MediaController.php
+++ b/app/Http/Controllers/Api/V1/Media/MediaController.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Facades\Storage;
 
 class MediaController extends Controller {
     public function download(Video $video) {
-        if (Auth::id() === null) {
-            abort(403, 'Forbidden Action');
+        if (! $video->downloadsEnabled() || (Auth::id() === null && $video->folder->category->require_login_for_downloads)) {
+            abort(403);
         }
 
         $path = substr($video->path, 7); // relative path from public disk

--- a/app/Http/Controllers/Api/V1/SeriesController.php
+++ b/app/Http/Controllers/Api/V1/SeriesController.php
@@ -93,10 +93,10 @@ class SeriesController extends Controller {
         }
 
         $validated = $request->validate([
-            'allow_downloads' => 'sometimes|boolean',
+            'downloads_enabled' => 'sometimes|boolean',
         ]);
         $series->update($validated);
 
-        return response($series->only(['allow_downloads']));
+        return response($series->only(['downloads_enabled']));
     }
 }

--- a/app/Http/Controllers/Api/V1/SeriesController.php
+++ b/app/Http/Controllers/Api/V1/SeriesController.php
@@ -12,6 +12,7 @@ use App\Models\Series;
 use App\Traits\HasModelHelpers;
 use App\Traits\HasTags;
 use App\Traits\HttpResponses;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class SeriesController extends Controller {
@@ -79,5 +80,23 @@ class SeriesController extends Controller {
         $this->generateTagRelationships($series->id, $request->tags, $request->deleted_tags, 'series_id', FolderTag::class);
 
         return response()->json(new SeriesResource($series));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  int  $series_id
+     */
+    public function updateDownloadSettings(Request $request, Series $series) {
+        if (Auth::id() !== 1) {
+            return $this->forbidden();
+        }
+
+        $validated = $request->validate([
+            'allow_downloads' => 'sometimes|boolean',
+        ]);
+        $series->update($validated);
+
+        return response($series->only(['allow_downloads']));
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -27,8 +27,10 @@ class CategoryResource extends JsonResource {
             return $folder->series->total_size;
         });
 
+        $authenticatedRequest = Auth::user() && Auth::id() === 1;
+
         return [
-            'id' => (string) $this->id,
+            'id' => $this->id,
             'name' => $this->name,
             'default_folder_id' => $this->default_folder_id,
             'folders' => FolderResource::collection($folders),
@@ -37,7 +39,9 @@ class CategoryResource extends JsonResource {
             'total_size' => $totalSize ?? 0,
             'created_at' => $this->created_at,
             'last_scan' => $this->last_scan,
-            'is_private' => Auth::user() && Auth::id() === 1 ? $this->is_private : false,
+            'is_private' => $authenticatedRequest ? $this->is_private : false,
+            'allow_downloads' => $authenticatedRequest ? $this->allow_downloads : false,
+            'require_login_for_downloads' => $authenticatedRequest ? $this->require_login_for_downloads : true,
         ];
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -40,8 +40,8 @@ class CategoryResource extends JsonResource {
             'created_at' => $this->created_at,
             'last_scan' => $this->last_scan,
             'is_private' => $authenticatedRequest ? $this->is_private : false,
-            'allow_downloads' => $authenticatedRequest ? $this->allow_downloads : false,
-            'require_login_for_downloads' => $authenticatedRequest ? $this->require_login_for_downloads : true,
+            'downloads_enabled' => $authenticatedRequest ? $this->downloads_enabled : false,
+            'downloads_require_auth' => $authenticatedRequest ? $this->downloads_require_auth : true,
         ];
     }
 }

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -27,7 +27,7 @@ class CategoryResource extends JsonResource {
             return $folder->series->total_size;
         });
 
-        $authenticatedRequest = Auth::user() && Auth::id() === 1;
+        $authenticatedRequest = Auth::id() === 1;
 
         return [
             'id' => $this->id,

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -31,6 +31,7 @@ class SeriesResource extends JsonResource {
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'edited_at' => $this->edited_at,
+            'allow_downloads' => $this->allow_downloads,
         ];
     }
 }

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -31,7 +31,7 @@ class SeriesResource extends JsonResource {
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'edited_at' => $this->edited_at,
-            'allow_downloads' => $this->allow_downloads,
+            'downloads_enabled' => $this->downloads_enabled,
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -15,6 +15,11 @@ class Category extends Model {
 
     protected $fillable = ['name', 'default_folder_id', 'editor_id'];
 
+    protected $casts = [
+        'allow_downloads' => 'boolean',
+        'require_login_for_downloads' => 'boolean',
+    ];
+
     public function folders(): HasMany {
         return $this->hasMany(Folder::class);
     }
@@ -29,5 +34,9 @@ class Category extends Model {
 
     public function sizeHistory(): HasMany {
         return $this->hasMany(LibrarySizeHistory::class);
+    }
+
+    public function downloadsEnabled(): bool {
+        return $this->allow_downloads;
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -13,11 +13,11 @@ class Category extends Model {
 
     public $timestamps = false;
 
-    protected $fillable = ['name', 'default_folder_id', 'editor_id', 'allow_downloads', 'require_login_for_downloads'];
+    protected $fillable = ['name', 'default_folder_id', 'editor_id', 'downloads_enabled', 'downloads_require_auth'];
 
     protected $casts = [
-        'allow_downloads' => 'boolean',
-        'require_login_for_downloads' => 'boolean',
+        'downloads_enabled' => 'boolean',
+        'downloads_require_auth' => 'boolean',
     ];
 
     public function folders(): HasMany {
@@ -37,6 +37,6 @@ class Category extends Model {
     }
 
     public function downloadsEnabled(): bool {
-        return $this->allow_downloads;
+        return $this->downloads_enabled;
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -13,7 +13,7 @@ class Category extends Model {
 
     public $timestamps = false;
 
-    protected $fillable = ['name', 'default_folder_id', 'editor_id'];
+    protected $fillable = ['name', 'default_folder_id', 'editor_id', 'allow_downloads', 'require_login_for_downloads'];
 
     protected $casts = [
         'allow_downloads' => 'boolean',

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -12,6 +12,17 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 class Folder extends Model {
     use HasFactory;
 
+    /**
+     * id                   -> int8 (pk) (index)
+     * category_id          -> int8 (fk)
+     *
+     * name                 -> varchar(255)
+     * path                 -> varchar(255) (index) (unique)
+     *
+     * created_at           -> timestamp (nullable)
+     *
+     * last_scan            -> int8 (default=0) (unused)
+     */
     public $timestamps = false;
 
     protected $casts = [
@@ -51,5 +62,13 @@ class Folder extends Model {
             ->first();
 
         return $counts->total > 0 && $counts->audio >= ($counts->total / 2);
+    }
+
+    public function downloadsEnabled(): bool {
+        if (! $this->category?->downloadsEnabled()) {
+            return false;
+        }
+
+        return $this->series?->allow_downloads ?? false;
     }
 }

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -69,6 +69,6 @@ class Folder extends Model {
             return false;
         }
 
-        return $this->series?->allow_downloads ?? false;
+        return $this->series?->downloads_enabled ?? false;
     }
 }

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -59,7 +59,7 @@ class Series extends Model {
         'file_count',
         'thumbnail_url',
         'edited_at',
-        'allow_downloads',
+        'downloads_enabled',
     ];
 
     protected $casts = [
@@ -71,7 +71,7 @@ class Series extends Model {
 
         'edited_at' => 'datetime',
 
-        'allow_downloads' => 'boolean',
+        'downloads_enabled' => 'boolean',
     ];
 
     public function folder(): BelongsTo {
@@ -106,6 +106,6 @@ class Series extends Model {
             return false;
         }
 
-        return $this->allow_downloads;
+        return $this->downloads_enabled;
     }
 }

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -69,6 +69,8 @@ class Series extends Model {
         'updated_at' => 'datetime',
 
         'edited_at' => 'datetime',
+
+        'allow_downloads' => 'boolean',
     ];
 
     public function folder(): BelongsTo {
@@ -96,5 +98,13 @@ class Series extends Model {
             'studio',
             'thumbnail_url',
         ];
+    }
+
+    public function downloadsEnabled(): bool {
+        if (! $this->folder?->category?->downloadsEnabled()) {
+            return false;
+        }
+
+        return $this->allow_downloads;
     }
 }

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -59,6 +59,7 @@ class Series extends Model {
         'file_count',
         'thumbnail_url',
         'edited_at',
+        'allow_downloads',
     ];
 
     protected $casts = [

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -50,4 +50,8 @@ class Video extends Model {
     public function metadata(): HasOne {
         return $this->hasOne(Metadata::class);
     }
+
+    public function downloadsEnabled(): bool {
+        return $this->folder?->downloadsEnabled() ?? false;
+    }
 }

--- a/app/Traits/LogsDownloads.php
+++ b/app/Traits/LogsDownloads.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+trait LogsDownloads {
+    protected function logDownloadAttempt(string $status, array $data): void {
+        $logContext = array_merge([
+            'user_id' => Auth::id() ?? 'guest',
+            'user_email' => Auth::user()?->email ?? 'guest',
+            'user_ip' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+            'status' => $status,
+            'timestamp' => now()->toDateTimeString(),
+        ], $data);
+
+        match ($status) {
+            'success' => Log::info('Download completed', $logContext),
+            'blocked' => Log::warning('Download blocked', $logContext),
+            'failed' => Log::error('Download failed', $logContext),
+            default => Log::debug('Download attempt', $logContext),
+        };
+    }
+}

--- a/app/Traits/LogsDownloads.php
+++ b/app/Traits/LogsDownloads.php
@@ -2,16 +2,23 @@
 
 namespace App\Traits;
 
+use App\Models\Video;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 trait LogsDownloads {
-    protected function logDownloadAttempt(string $status, array $data): void {
+    protected function logDownloadAttempt(Video $file, string $status, array $data): void {
         $logContext = array_merge([
-            'user_id' => Auth::id() ?? 'guest',
-            'user_email' => Auth::user()?->email ?? 'guest',
-            'user_ip' => request()->ip(),
-            'user_agent' => request()->userAgent(),
+            'file' => [
+                'id' => $file->id,
+                'file_path' => $file->path,
+            ],
+            'user' => [
+                'id' => Auth::id() ?? 'guest',
+                'email' => Auth::user()?->email ?? 'guest',
+                'ip' => request()->ip(),
+                'user_agent' => request()->userAgent(),
+            ],
             'status' => $status,
             'timestamp' => now()->toDateTimeString(),
         ], $data);

--- a/config/media.php
+++ b/config/media.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'downloads' => [
+        'max_size_mb' => env('MAX_DOWNLOAD_SIZE_MB', 1024 * 6),
+    ],
+];

--- a/database/migrations/2026_04_09_213400_add_downloadable_flags_to_libraries_and_folders.php
+++ b/database/migrations/2026_04_09_213400_add_downloadable_flags_to_libraries_and_folders.php
@@ -10,12 +10,12 @@ return new class extends Migration {
      */
     public function up(): void {
         Schema::table('categories', function (Blueprint $table) {
-            $table->boolean('allow_downloads')->default(false);
-            $table->boolean('require_login_for_downloads')->default(true);
+            $table->boolean('downloads_enabled')->default(false);
+            $table->boolean('downloads_require_auth')->default(true);
         });
 
         Schema::table('series', function (Blueprint $table) {
-            $table->boolean('allow_downloads')->default(true);
+            $table->boolean('downloads_enabled')->default(true);
         });
     }
 
@@ -24,11 +24,11 @@ return new class extends Migration {
      */
     public function down(): void {
         Schema::table('categories', function (Blueprint $table) {
-            $table->dropColumn(['allow_downloads', 'require_login_for_downloads']);
+            $table->dropColumn(['downloads_enabled', 'downloads_require_auth']);
         });
 
         Schema::table('series', function (Blueprint $table) {
-            $table->dropColumn('allow_downloads');
+            $table->dropColumn('downloads_enabled');
         });
     }
 };

--- a/database/migrations/2026_04_09_213400_add_downloadable_flags_to_libraries_and_folders.php
+++ b/database/migrations/2026_04_09_213400_add_downloadable_flags_to_libraries_and_folders.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->boolean('allow_downloads')->default(false);
+            $table->boolean('require_login_for_downloads')->default(true);
+        });
+
+        Schema::table('series', function (Blueprint $table) {
+            $table->boolean('allow_downloads')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn(['allow_downloads', 'require_login_for_downloads']);
+        });
+
+        Schema::table('series', function (Blueprint $table) {
+            $table->dropColumn('allow_downloads');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3252,16 +3252,26 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "devOptional": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/b4a": {

--- a/resources/js/components/cards/data/LibraryCard.vue
+++ b/resources/js/components/cards/data/LibraryCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { CategoryResource, FolderResource } from '@/types/resources';
 
-import { startScanFilesTask, startVerifyFilesTask, toggleCategoryPrivacy } from '@/service/siteAPI';
+import { setLibraryDownloadSettings, startScanFilesTask, startVerifyFilesTask, toggleCategoryPrivacy } from '@/service/siteAPI';
 import { formatFileSize, handleStorageURL, toFormattedDate } from '@/service/util';
 import { computed, ref, useTemplateRef, watch } from 'vue';
 import { useQueryClient } from '@tanstack/vue-query';
@@ -13,6 +13,7 @@ import LibraryCardMenu from '@/components/menus/LibraryCardMenu.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
+import TablerDownload from '~icons/tabler/download';
 import ProiconsLock from '~icons/proicons/lock';
 
 const props = defineProps<{ data?: CategoryResource }>();
@@ -86,6 +87,42 @@ const handleTogglePrivacy = async (id: number, currentValue: boolean) => {
     }
 };
 
+const handleToggleDownloads = async (id: number, currentValue: boolean) => {
+    if (processing.value || !props.data?.id || currentValue !== props.data.allow_downloads) return;
+
+    try {
+        processing.value = true;
+
+        await setLibraryDownloadSettings(id, { allow_downloads: !currentValue });
+        await queryClient.invalidateQueries({ queryKey: ['categories'] });
+
+        toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Library Downloads.`);
+        processing.value = false;
+    } catch (error) {
+        toast('Failure', { type: 'danger', description: 'Unable to set download settings.' });
+        console.error(error);
+        processing.value = false;
+    }
+};
+
+const handleToggleDownloadPrivacy = async (id: number, currentValue: boolean) => {
+    if (processing.value || !props.data?.id || currentValue !== props.data.require_login_for_downloads) return;
+
+    try {
+        processing.value = true;
+
+        await setLibraryDownloadSettings(id, { require_login_for_downloads: !currentValue });
+        await queryClient.invalidateQueries({ queryKey: ['categories'] });
+
+        toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Library Downloads for Guest Users.`);
+        processing.value = false;
+    } catch (error) {
+        toast('Failure', { type: 'danger', description: 'Unable to set download settings.' });
+        console.error(error);
+        processing.value = false;
+    }
+};
+
 watch(
     () => props.data,
     () => {
@@ -105,13 +142,18 @@ watch(
                 :src="handleStorageURL(defaultFolder?.series?.thumbnail_url) ?? '/storage/thumbnails/default.webp'"
                 alt="Folder Cover Art"
             />
-            <span class="ring-primary/90 absolute inset-0 h-full w-full rounded-t-xl p-2.5 transition duration-(--duration-input) ease-in-out ring-inset hover:ring-2">
-                <div
-                    v-show="data?.is_private"
-                    class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button ml-auto size-7 shrink-0 rounded-full p-1 ring-1"
-                    title="is private"
-                >
+            <span
+                class="ring-primary/90 absolute inset-0 flex h-full w-full flex-col items-end gap-2 rounded-t-xl p-2.5 transition duration-(--duration-input) ease-in-out ring-inset hover:ring-2"
+            >
+                <div v-show="data?.is_private" class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button size-7 shrink-0 rounded-full p-1 ring-1" title="is private">
                     <ProiconsLock class="size-5" />
+                </div>
+                <div
+                    v-show="data?.allow_downloads"
+                    class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button size-7 shrink-0 rounded-full p-1 pt-0.5 ring-1"
+                    title="is downloadable"
+                >
+                    <TablerDownload class="size-5" />
                 </div>
             </span>
         </RouterLink>
@@ -132,6 +174,8 @@ watch(
                                 :handle-set-default-folder="handleSetDefaultFolder"
                                 :handle-start-scan="handleStartScan"
                                 :handle-toggle-privacy="handleTogglePrivacy"
+                                :handle-toggle-downloads="handleToggleDownloads"
+                                :handle-toggle-download-privacy="handleToggleDownloadPrivacy"
                             />
                         </template>
                     </BasePopover>

--- a/resources/js/components/cards/data/LibraryCard.vue
+++ b/resources/js/components/cards/data/LibraryCard.vue
@@ -7,6 +7,7 @@ import { computed, ref, useTemplateRef, watch } from 'vue';
 import { useQueryClient } from '@tanstack/vue-query';
 import { updateCategory } from '@/service/mediaAPI.ts';
 import { BasePopover } from '@/components/cedar-ui/popover';
+import { ButtonIcon } from '@/components/cedar-ui/button';
 import { toast } from '@aminnausin/cedar-ui';
 
 import LibraryCardMenu from '@/components/menus/LibraryCardMenu.vue';
@@ -14,6 +15,7 @@ import TablerDownload from '@/components/icons/TablerDownload.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
+import CircumShare1 from '~icons/circum/share-1';
 import ProiconsLock from '~icons/proicons/lock';
 
 const props = defineProps<{ data?: CategoryResource }>();
@@ -136,7 +138,7 @@ watch(
 
 <template>
     <div class="data-card group flex w-full flex-col rounded-xl shadow-lg ring-1 ring-gray-900/5">
-        <RouterLink :to="`/${data?.name}`" class="peer relative h-40 w-full">
+        <RouterLink :to="`/dashboard/libraries/${data?.id}`" class="peer relative h-40 w-full" title="View Folders">
             <LazyImage
                 class="peer mb-auto h-full w-full rounded-t-xl object-cover shadow-xs ring-1 ring-gray-900/5 ring-inset hover:ring-4"
                 :src="handleStorageURL(defaultFolder?.series?.thumbnail_url) ?? '/storage/thumbnails/default.webp'"
@@ -161,6 +163,9 @@ watch(
             <div class="flex flex-wrap items-center justify-between gap-1">
                 <h3 class="group-hover:text-primary capitalize">{{ data?.id }} - {{ data?.name }}</h3>
                 <span class="flex gap-2 text-sm *:h-6">
+                    <ButtonIcon :title="'Open Default Folder In New Tab'" :to="`/${data?.name}`" :target="'_blank'" class="size-6 p-0">
+                        <template #icon><CircumShare1 class="size-4" /></template>
+                    </ButtonIcon>
                     <BasePopover popoverClass="max-w-56! rounded-lg mt-8" :buttonClass="'p-1! ml-auto'" ref="popover">
                         <template #buttonIcon>
                             <ProiconsMoreVertical class="size-4" />

--- a/resources/js/components/cards/data/LibraryCard.vue
+++ b/resources/js/components/cards/data/LibraryCard.vue
@@ -88,12 +88,12 @@ const handleTogglePrivacy = async (id: number, currentValue: boolean) => {
 };
 
 const handleToggleDownloads = async (id: number, currentValue: boolean) => {
-    if (processing.value || !props.data?.id || currentValue !== props.data.allow_downloads) return;
+    if (processing.value || !props.data?.id || currentValue !== props.data.downloads_enabled) return;
 
     try {
         processing.value = true;
 
-        await setLibraryDownloadSettings(id, { allow_downloads: !currentValue });
+        await setLibraryDownloadSettings(id, { downloads_enabled: !currentValue });
         await queryClient.invalidateQueries({ queryKey: ['categories'] });
 
         toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Library Downloads.`);
@@ -106,12 +106,12 @@ const handleToggleDownloads = async (id: number, currentValue: boolean) => {
 };
 
 const handleToggleDownloadPrivacy = async (id: number, currentValue: boolean) => {
-    if (processing.value || !props.data?.id || currentValue !== props.data.require_login_for_downloads) return;
+    if (processing.value || !props.data?.id || currentValue !== props.data.downloads_require_auth) return;
 
     try {
         processing.value = true;
 
-        await setLibraryDownloadSettings(id, { require_login_for_downloads: !currentValue });
+        await setLibraryDownloadSettings(id, { downloads_require_auth: !currentValue });
         await queryClient.invalidateQueries({ queryKey: ['categories'] });
 
         toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Library Downloads for Guest Users.`);
@@ -149,7 +149,7 @@ watch(
                     <ProiconsLock class="size-5" />
                 </div>
                 <div
-                    v-show="data?.allow_downloads"
+                    v-show="data?.downloads_enabled"
                     class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button size-7 shrink-0 rounded-full p-1 pt-0.5 ring-1"
                     title="is downloadable"
                 >

--- a/resources/js/components/cards/data/LibraryCard.vue
+++ b/resources/js/components/cards/data/LibraryCard.vue
@@ -10,10 +10,10 @@ import { BasePopover } from '@/components/cedar-ui/popover';
 import { toast } from '@aminnausin/cedar-ui';
 
 import LibraryCardMenu from '@/components/menus/LibraryCardMenu.vue';
+import TablerDownload from '@/components/icons/TablerDownload.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
-import TablerDownload from '~icons/tabler/download';
 import ProiconsLock from '~icons/proicons/lock';
 
 const props = defineProps<{ data?: CategoryResource }>();

--- a/resources/js/components/cards/data/LibraryFolderCard.vue
+++ b/resources/js/components/cards/data/LibraryFolderCard.vue
@@ -2,18 +2,51 @@
 import type { FolderResource } from '@/types/resources';
 
 import { formatFileSize, handleStorageURL, toFormattedDate } from '@/service/util';
-import { useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
+import { setSeriesDownloadSettings } from '@/service/siteAPI';
+import { useDashboardStore } from '@/stores/DashboardStore';
+import { useQueryClient } from '@tanstack/vue-query';
 import { BasePopover } from '@/components/cedar-ui/popover';
+import { storeToRefs } from 'pinia';
 import { ButtonIcon } from '@/components/cedar-ui/button';
+import { toast } from '@aminnausin/cedar-ui';
 
 import LibraryFolderCardMenu from '@/components/menus/LibraryFolderCardMenu.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
+import TablerDownload from '~icons/tabler/download';
 import CircumShare1 from '~icons/circum/share-1';
 
-defineProps<{ data: FolderResource }>();
+const { stateLibraryId, stateLibraries } = storeToRefs(useDashboardStore());
+
+const props = defineProps<{ data: FolderResource }>();
 const popover = useTemplateRef('popover');
+
+const queryClient = useQueryClient();
+const processing = ref(false);
+
+const stateLibraryIsDownloadable = computed(() => {
+    return stateLibraries.value.find((lib) => lib.id === stateLibraryId.value)?.allow_downloads ?? false;
+});
+
+const handleToggleDownloads = async (id: number, currentValue: boolean) => {
+    if (processing.value || !props.data?.id || currentValue !== props.data.series?.allow_downloads) return;
+
+    try {
+        processing.value = true;
+
+        await setSeriesDownloadSettings(id, { allow_downloads: !currentValue });
+        await queryClient.invalidateQueries({ queryKey: ['libraryFolders', stateLibraryId.value] });
+
+        toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Folder Downloads.`);
+        processing.value = false;
+    } catch (error) {
+        toast('Failure', { type: 'danger', description: 'Unable to set download settings.' });
+        console.error(error);
+        processing.value = false;
+    }
+};
 </script>
 
 <template>
@@ -25,11 +58,21 @@ const popover = useTemplateRef('popover');
                 alt="Folder Cover Art"
             />
 
-            <span class="ring-primary/90 absolute top-0 left-0 h-full w-full rounded-t-md ring-inset hover:ring-2"></span>
+            <span
+                class="ring-primary/90 absolute inset-0 flex h-full w-full flex-col items-end gap-2 rounded-t-xl p-2.5 transition duration-(--duration-input) ease-in-out ring-inset hover:ring-2"
+            >
+                <div
+                    v-show="data.series?.allow_downloads && stateLibraryIsDownloadable"
+                    class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button size-7 shrink-0 rounded-full p-1 pt-0.5 ring-1"
+                    title="is downloadable"
+                >
+                    <TablerDownload class="size-5" />
+                </div>
+            </span>
         </RouterLink>
         <section class="flex h-full flex-1 flex-col gap-2 p-3" v-if="data">
             <div class="xs:flex-nowrap flex flex-wrap items-start justify-between gap-1">
-                <h3 class="group-hover:text-primary capitalize">{{ data.id }} - {{ data?.title ?? data?.name }}</h3>
+                <h3 class="group-hover:text-primary capitalize">{{ data.id }} - {{ data?.title ?? data?.name }} {{ stateLibraryIsDownloadable }}</h3>
                 <span class="flex gap-2 text-sm *:h-6">
                     <ButtonIcon :title="'Open Folder In New Tab'" :to="`/${encodeURI(data.path)}`" :target="'_blank'" class="size-6 p-0">
                         <template #icon><CircumShare1 class="size-4" /></template>
@@ -39,7 +82,14 @@ const popover = useTemplateRef('popover');
                             <ProiconsMoreVertical class="size-4" />
                         </template>
                         <template #content>
-                            <LibraryFolderCardMenu :data="data" :handle-close-popover="popover?.handleClose" @clickAction="$emit('clickAction', data?.id)" />
+                            <LibraryFolderCardMenu
+                                :data="data"
+                                :processing="processing"
+                                :library-downloads-enabled="stateLibraryIsDownloadable"
+                                :handle-close-popover="popover?.handleClose"
+                                :handle-toggle-downloads="handleToggleDownloads"
+                                @clickAction="$emit('clickAction', data?.id)"
+                            />
                         </template>
                     </BasePopover>
                 </span>

--- a/resources/js/components/cards/data/LibraryFolderCard.vue
+++ b/resources/js/components/cards/data/LibraryFolderCard.vue
@@ -31,7 +31,7 @@ const popover = useTemplateRef('popover');
             <div class="xs:flex-nowrap flex flex-wrap items-start justify-between gap-1">
                 <h3 class="group-hover:text-primary capitalize">{{ data.id }} - {{ data?.title ?? data?.name }}</h3>
                 <span class="flex gap-2 text-sm *:h-6">
-                    <ButtonIcon :title="'Open Folder In New Tab'" :to="`/${encodeURI(data.path)}`" class="size-6 p-0">
+                    <ButtonIcon :title="'Open Folder In New Tab'" :to="`/${encodeURI(data.path)}`" :target="'_blank'" class="size-6 p-0">
                         <template #icon><CircumShare1 class="size-4" /></template>
                     </ButtonIcon>
                     <BasePopover popoverClass="max-w-56! rounded-lg mt-8" :buttonClass="'p-1! ml-auto'" ref="popover">

--- a/resources/js/components/cards/data/LibraryFolderCard.vue
+++ b/resources/js/components/cards/data/LibraryFolderCard.vue
@@ -72,7 +72,7 @@ const handleToggleDownloads = async (id: number, currentValue: boolean) => {
         </RouterLink>
         <section class="flex h-full flex-1 flex-col gap-2 p-3" v-if="data">
             <div class="xs:flex-nowrap flex flex-wrap items-start justify-between gap-1">
-                <h3 class="group-hover:text-primary capitalize">{{ data.id }} - {{ data?.title ?? data?.name }} {{ stateLibraryIsDownloadable }}</h3>
+                <h3 class="group-hover:text-primary capitalize">{{ data.id }} - {{ data?.title ?? data?.name }}</h3>
                 <span class="flex gap-2 text-sm *:h-6">
                     <ButtonIcon :title="'Open Folder In New Tab'" :to="`/${encodeURI(data.path)}`" :target="'_blank'" class="size-6 p-0">
                         <template #icon><CircumShare1 class="size-4" /></template>

--- a/resources/js/components/cards/data/LibraryFolderCard.vue
+++ b/resources/js/components/cards/data/LibraryFolderCard.vue
@@ -27,16 +27,16 @@ const queryClient = useQueryClient();
 const processing = ref(false);
 
 const stateLibraryIsDownloadable = computed(() => {
-    return stateLibraries.value.find((lib) => lib.id === stateLibraryId.value)?.allow_downloads ?? false;
+    return stateLibraries.value.find((lib) => lib.id === stateLibraryId.value)?.downloads_enabled ?? false;
 });
 
 const handleToggleDownloads = async (id: number, currentValue: boolean) => {
-    if (processing.value || !props.data?.id || currentValue !== props.data.series?.allow_downloads) return;
+    if (processing.value || !props.data?.id || currentValue !== props.data.series?.downloads_enabled) return;
 
     try {
         processing.value = true;
 
-        await setSeriesDownloadSettings(id, { allow_downloads: !currentValue });
+        await setSeriesDownloadSettings(id, { downloads_enabled: !currentValue });
         await queryClient.invalidateQueries({ queryKey: ['libraryFolders', stateLibraryId.value] });
 
         toast.success(`${currentValue ? 'Disabled' : 'Enabled'} Folder Downloads.`);
@@ -62,7 +62,7 @@ const handleToggleDownloads = async (id: number, currentValue: boolean) => {
                 class="ring-primary/90 absolute inset-0 flex h-full w-full flex-col items-end gap-2 rounded-t-xl p-2.5 transition duration-(--duration-input) ease-in-out ring-inset hover:ring-2"
             >
                 <div
-                    v-show="data.series?.allow_downloads && stateLibraryIsDownloadable"
+                    v-show="data.series?.downloads_enabled && stateLibraryIsDownloadable"
                     class="bg-surface-2 text-primary dark:text-foreground-0 ring-r-button size-7 shrink-0 rounded-full p-1 pt-0.5 ring-1"
                     title="is downloadable"
                 >

--- a/resources/js/components/cards/data/LibraryFolderCard.vue
+++ b/resources/js/components/cards/data/LibraryFolderCard.vue
@@ -12,10 +12,10 @@ import { ButtonIcon } from '@/components/cedar-ui/button';
 import { toast } from '@aminnausin/cedar-ui';
 
 import LibraryFolderCardMenu from '@/components/menus/LibraryFolderCardMenu.vue';
+import TablerDownload from '@/components/icons/TablerDownload.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
-import TablerDownload from '~icons/tabler/download';
 import CircumShare1 from '~icons/circum/share-1';
 
 const { stateLibraryId, stateLibraries } = storeToRefs(useDashboardStore());

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -33,7 +33,7 @@ const { userData } = storeToRefs(useAuthStore());
 
 const { title, views, duration } = useMetaData(toRef(() => videoData));
 
-const resumeOffset = computed(() => (videoData.metadata?.progress_offset ? `&t=${videoData.metadata.progress_offset}` : ''));
+const resumeOffset = computed(() => (videoData.metadata?.progress_offset && videoData.metadata.progress_percentage !== 100 ? `&t=${videoData.metadata.progress_offset}` : ''));
 
 const isAudio = computed(() => {
     return videoData.metadata?.media_type === MediaType.AUDIO;

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -79,7 +79,8 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
             'dark:bg-primary-dark-800/70 dark:odd:bg-primary-dark-600 hover:bg-primary/5 bg-neutral-50 odd:bg-neutral-100',
             'p-3',
             'relative flex w-full cursor-pointer flex-col flex-wrap gap-x-8 gap-y-4 rounded-md shadow-sm ring-inset',
-            'data-card group',
+            'data-card',
+            'hover:data-card-hover',
         ]"
         :to="encodeURI(`/${stateDirectory.name}/${stateFolder.name}?video=${videoData.id}${resumeOffset}`)"
         :videoData-id="videoData.id"
@@ -104,7 +105,7 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
                     :hover-card-leave-delay="300"
                 >
                     <template #trigger>
-                        <ProiconsComment class="my-auto size-5 shrink-0 opacity-100 transition-opacity duration-300 group-hover:opacity-20" title="Description" />
+                        <ProiconsComment class="my-auto size-5 shrink-0 opacity-100 transition-opacity duration-300 hover:opacity-20" title="Description" />
                     </template>
                 </HoverCard>
                 <HoverCard class="xs:block hidden" v-if="videoData.metadata?.lyrics" :content-title="'Has Lyrics'" :hover-card-delay="400" :hover-card-leave-delay="300">
@@ -173,11 +174,16 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
                 <MediaTag v-for="(tag, index) in videoData.video_tags" :key="index" :label="tag.name" />
             </span>
         </section>
-        <div :class="[{ 'ring-primary-muted dark:ring-primary-active ring-2': currentID === videoData.id }, 'absolute top-0 left-0 z-1 h-full w-full rounded-md ring-inset']"></div>
+        <div
+            :class="[
+                { 'ring-primary-muted dark:ring-primary-active ring-2': currentID === videoData.id },
+                'pointer-events-none absolute top-0 left-0 z-1 h-full w-full rounded-md ring-inset',
+            ]"
+        ></div>
         <div
             v-if="videoData.metadata?.progress_percentage && videoData.metadata.progress_percentage !== 100"
             :class="
-                cn('absolute bottom-0 left-0 flex h-1 w-full items-end overflow-clip rounded-b-md opacity-80 group-hover:opacity-100 dark:opacity-60', {
+                cn('playback-progress-bar absolute bottom-0 left-0 flex h-1 w-full items-end overflow-clip rounded-b-md opacity-80 dark:opacity-60', {
                     'bottom-0.5 opacity-100 dark:opacity-100': currentID === videoData.id,
                 })
             "
@@ -191,3 +197,8 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
         </div>
     </RouterLink>
 </template>
+<style lang="css" scoped>
+.data-card-hover .playback-progress-bar {
+    opacity: 1;
+}
+</style>

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -33,7 +33,7 @@ const { userData } = storeToRefs(useAuthStore());
 
 const { title, views, duration } = useMetaData(toRef(() => videoData));
 
-const resumeOffset = computed(() => (videoData.metadata?.progress_offset && videoData.metadata.progress_percentage !== 100 ? `&t=${videoData.metadata.progress_offset}` : ''));
+const resumeOffset = computed(() => (videoData.metadata?.progress_offset && videoData.metadata.progress_percentage < 95 ? `&t=${videoData.metadata.progress_offset}` : ''));
 
 const isAudio = computed(() => {
     return videoData.metadata?.media_type === MediaType.AUDIO;

--- a/resources/js/components/dashboard/DashboardLibraries.vue
+++ b/resources/js/components/dashboard/DashboardLibraries.vue
@@ -20,8 +20,8 @@ import EditFolderModal from '@/components/modals/EditFolderModal.vue';
 import LibraryCard from '@/components/cards/data/LibraryCard.vue';
 import useModal from '@/composables/useModal';
 
+import ProiconsArrowSync from '~icons/proicons/arrow-sync';
 import ProiconsLibrary from '~icons/proicons/library';
-import ProiconsSearch from '~icons/proicons/search';
 import ProiconsHome2 from '~icons/proicons/home-2';
 import ProiconsAdd from '~icons/proicons/add';
 
@@ -220,7 +220,7 @@ watchEffect(() => {
                 <template #icon><ProiconsAdd /></template>
             </ButtonText>
             <ButtonText @click="handleStartScan" title="Index Files" text="Scan For Changes" class="xs:flex-initial flex-1">
-                <template #icon><ProiconsSearch /></template>
+                <template #icon><ProiconsArrowSync /></template>
             </ButtonText>
         </div>
     </div>

--- a/resources/js/components/icons/TablerDownload.vue
+++ b/resources/js/components/icons/TablerDownload.vue
@@ -5,7 +5,7 @@
             stroke="currentColor"
             stroke-linecap="round"
             stroke-linejoin="round"
-            stroke-width="1"
+            stroke-width="1.5"
             d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2M7 11l5 5l5-5m-5-7v12"
         />
     </svg>

--- a/resources/js/components/icons/TablerDownload.vue
+++ b/resources/js/components/icons/TablerDownload.vue
@@ -1,0 +1,12 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+            d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2M7 11l5 5l5-5m-5-7v12"
+        />
+    </svg>
+</template>

--- a/resources/js/components/icons/TablerDownloadOff.vue
+++ b/resources/js/components/icons/TablerDownloadOff.vue
@@ -5,7 +5,7 @@
             stroke="currentColor"
             stroke-linecap="round"
             stroke-linejoin="round"
-            stroke-width="1"
+            stroke-width="1.5"
             d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 1.83-1.19M7 11l5 5l2-2m2-2l1-1m-5-7v4m0 4v4M3 3l18 18"
         />
     </svg>

--- a/resources/js/components/icons/TablerDownloadOff.vue
+++ b/resources/js/components/icons/TablerDownloadOff.vue
@@ -1,0 +1,12 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+            d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 1.83-1.19M7 11l5 5l2-2m2-2l1-1m-5-7v4m0 4v4M3 3l18 18"
+        />
+    </svg>
+</template>

--- a/resources/js/components/menus/LibraryCardMenu.vue
+++ b/resources/js/components/menus/LibraryCardMenu.vue
@@ -6,14 +6,14 @@ import { ButtonText } from '@/components/cedar-ui/button';
 import { FormLabel } from '@/components/cedar-ui/form';
 import { FLAGS } from '@/config/featureFlags';
 
+import TablerDownloadOff from '@/components/icons/TablerDownloadOff.vue';
+import TablerDownload from '@/components/icons/TablerDownload.vue';
+
 import ProiconsArrowSync from '~icons/proicons/arrow-sync';
 import ProiconsLockOpen from '~icons/proicons/lock-open';
 import CircumFolderOn from '~icons/circum/folder-on';
 import ProiconsDelete from '~icons/proicons/delete';
 import ProiconsLock from '~icons/proicons/lock';
-
-import TablerDownloadOff from '~icons/tabler/download-off';
-import TablerDownload from '~icons/tabler/download';
 
 const props = withDefaults(
     defineProps<{

--- a/resources/js/components/menus/LibraryCardMenu.vue
+++ b/resources/js/components/menus/LibraryCardMenu.vue
@@ -12,6 +12,9 @@ import CircumFolderOn from '~icons/circum/folder-on';
 import ProiconsDelete from '~icons/proicons/delete';
 import ProiconsLock from '~icons/proicons/lock';
 
+import TablerDownloadOff from '~icons/tabler/download-off';
+import TablerDownload from '~icons/tabler/download';
+
 const props = withDefaults(
     defineProps<{
         data?: CategoryResource;
@@ -21,6 +24,8 @@ const props = withDefaults(
         handleSetDefaultFolder: (newFolder: { value: number }) => Promise<void>;
         handleStartScan: (verifyOnly?: boolean) => Promise<void>;
         handleTogglePrivacy: (id: number, currentValue: boolean) => Promise<void>;
+        handleToggleDownloads: (id: number, currentValue: boolean) => Promise<void>;
+        handleToggleDownloadPrivacy: (id: number, currentValue: boolean) => Promise<void>;
     }>(),
     {},
 );
@@ -65,6 +70,22 @@ const props = withDefaults(
                 <p class="flex-1 text-start">Manage Folders</p>
                 <template #icon> <CircumFolderOn class="order-1 size-4" /></template>
             </ButtonText>
+
+            <ButtonText :title="'Toggle Downloads'" @click="handleToggleDownloads(data.id, data.allow_downloads)" :disabled="processing">
+                <p class="flex-1 text-start">{{ data.allow_downloads ? 'Disable Downloads' : 'Enable Downloads' }}</p>
+                <template #icon> <TablerDownloadOff v-if="!data.allow_downloads" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
+            </ButtonText>
+
+            <ButtonText
+                v-if="data.allow_downloads"
+                :title="`${data.require_login_for_downloads ? 'Enable' : 'Disable'} Guest Downloads`"
+                @click="handleToggleDownloadPrivacy(data.id, data.require_login_for_downloads)"
+                :disabled="processing"
+            >
+                <p class="flex-1 text-start">{{ data.require_login_for_downloads ? 'Guest Downloads' : 'Private Downloads' }}</p>
+                <template #icon> <TablerDownloadOff v-if="!data.require_login_for_downloads" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
+            </ButtonText>
+
             <ButtonText
                 :title="'Toggle Privacy'"
                 @click="handleTogglePrivacy(data.id, data.is_private ?? false)"

--- a/resources/js/components/menus/LibraryCardMenu.vue
+++ b/resources/js/components/menus/LibraryCardMenu.vue
@@ -71,19 +71,19 @@ const props = withDefaults(
                 <template #icon> <CircumFolderOn class="order-1 size-4" /></template>
             </ButtonText>
 
-            <ButtonText :title="'Toggle Downloads'" @click="handleToggleDownloads(data.id, data.allow_downloads)" :disabled="processing">
-                <p class="flex-1 text-start">{{ data.allow_downloads ? 'Disable Downloads' : 'Enable Downloads' }}</p>
-                <template #icon> <TablerDownloadOff v-if="!data.allow_downloads" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
+            <ButtonText :title="'Toggle Downloads'" @click="handleToggleDownloads(data.id, data.downloads_enabled)" :disabled="processing">
+                <p class="flex-1 text-start">{{ data.downloads_enabled ? 'Disable Downloads' : 'Enable Downloads' }}</p>
+                <template #icon> <TablerDownloadOff v-if="!data.downloads_enabled" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
             </ButtonText>
 
             <ButtonText
-                v-if="data.allow_downloads"
-                :title="`${data.require_login_for_downloads ? 'Enable' : 'Disable'} Guest Downloads`"
-                @click="handleToggleDownloadPrivacy(data.id, data.require_login_for_downloads)"
+                v-if="data.downloads_enabled"
+                :title="`${data.downloads_require_auth ? 'Enable' : 'Disable'} Guest Downloads`"
+                @click="handleToggleDownloadPrivacy(data.id, data.downloads_require_auth)"
                 :disabled="processing"
             >
-                <p class="flex-1 text-start">{{ data.require_login_for_downloads ? 'Guest Downloads' : 'Private Downloads' }}</p>
-                <template #icon> <TablerDownloadOff v-if="!data.require_login_for_downloads" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
+                <p class="flex-1 text-start">{{ data.downloads_require_auth ? 'Guest Downloads' : 'Private Downloads' }}</p>
+                <template #icon> <TablerDownloadOff v-if="!data.downloads_require_auth" class="size-4" /> <TablerDownload v-else class="size-4" /></template>
             </ButtonText>
 
             <ButtonText

--- a/resources/js/components/menus/LibraryCardMenu.vue
+++ b/resources/js/components/menus/LibraryCardMenu.vue
@@ -4,6 +4,7 @@ import type { CategoryResource, FolderResource } from '@/types/resources';
 import { InputSelect } from '@/components/cedar-ui/select';
 import { ButtonText } from '@/components/cedar-ui/button';
 import { FormLabel } from '@/components/cedar-ui/form';
+import { FLAGS } from '@/config/featureFlags';
 
 import ProiconsArrowSync from '~icons/proicons/arrow-sync';
 import ProiconsLockOpen from '~icons/proicons/lock-open';
@@ -64,7 +65,12 @@ const props = withDefaults(
                 <p class="flex-1 text-start">Manage Folders</p>
                 <template #icon> <CircumFolderOn class="order-1 size-4" /></template>
             </ButtonText>
-            <ButtonText :title="'Toggle Privacy'" @click="handleTogglePrivacy(data.id, data.is_private ?? false)" :disabled="processing">
+            <ButtonText
+                :title="'Toggle Privacy'"
+                @click="handleTogglePrivacy(data.id, data.is_private ?? false)"
+                :disabled="processing"
+                :class="[{ 'text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!': data.is_private }]"
+            >
                 <p class="flex-1 text-start">{{ data.is_private ? 'Set to Public' : 'Set to Private' }}</p>
                 <template #icon> <ProiconsLock v-if="data.is_private" class="size-4" /> <ProiconsLockOpen v-else class="size-4" /></template>
             </ButtonText>
@@ -73,6 +79,7 @@ const props = withDefaults(
                 class="text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!"
                 title="Remove From Server"
                 disabled
+                v-if="FLAGS.USE_REMOVABLE_LIBRARIES"
             >
                 <p class="flex-1 text-start">Remove Library</p>
                 <template #icon> <ProiconsDelete class="size-4" /></template>

--- a/resources/js/components/menus/LibraryCardMenu.vue
+++ b/resources/js/components/menus/LibraryCardMenu.vue
@@ -11,7 +11,6 @@ import TablerDownload from '@/components/icons/TablerDownload.vue';
 
 import ProiconsArrowSync from '~icons/proicons/arrow-sync';
 import ProiconsLockOpen from '~icons/proicons/lock-open';
-import CircumFolderOn from '~icons/circum/folder-on';
 import ProiconsDelete from '~icons/proicons/delete';
 import ProiconsLock from '~icons/proicons/lock';
 
@@ -65,10 +64,6 @@ const props = withDefaults(
             <ButtonText title="Verify File Metadata" @click="handleStartScan(true)">
                 <p class="flex-1 text-start">Verify Files</p>
                 <template #icon> <ProiconsArrowSync class="size-4" /></template>
-            </ButtonText>
-            <ButtonText title="Manage all Folders in Library" :to="`/dashboard/libraries/${data?.id}`" target="">
-                <p class="flex-1 text-start">Manage Folders</p>
-                <template #icon> <CircumFolderOn class="order-1 size-4" /></template>
             </ButtonText>
 
             <ButtonText :title="'Toggle Downloads'" @click="handleToggleDownloads(data.id, data.downloads_enabled)" :disabled="processing">

--- a/resources/js/components/menus/LibraryFolderCardMenu.vue
+++ b/resources/js/components/menus/LibraryFolderCardMenu.vue
@@ -46,11 +46,11 @@ const props = withDefaults(
             <ButtonText
                 v-if="libraryDownloadsEnabled && data.series"
                 :title="'Toggle Downloads'"
-                @click="handleToggleDownloads(data.series.id, data.series.allow_downloads ?? false)"
+                @click="handleToggleDownloads(data.series.id, data.series.downloads_enabled ?? false)"
                 :disabled="processing"
             >
-                <p class="flex-1 text-start">{{ data.series?.allow_downloads ? 'Disable Downloads' : 'Enable Downloads' }}</p>
-                <template #icon> <TablerDownload v-if="data.series?.allow_downloads" class="size-4" /> <TablerDownloadOff v-else class="size-4" /></template>
+                <p class="flex-1 text-start">{{ data.series?.downloads_enabled ? 'Disable Downloads' : 'Enable Downloads' }}</p>
+                <template #icon> <TablerDownload v-if="data.series?.downloads_enabled" class="size-4" /> <TablerDownloadOff v-else class="size-4" /></template>
             </ButtonText>
 
             <ButtonText v-if="FLAGS.USE_REMOVABLE_FOLDERS" class="text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!" title="Remove From Server" disabled>

--- a/resources/js/components/menus/LibraryFolderCardMenu.vue
+++ b/resources/js/components/menus/LibraryFolderCardMenu.vue
@@ -4,8 +4,9 @@ import type { FolderResource } from '@/contracts/media';
 import { ButtonText } from '@/components/cedar-ui/button';
 import { FLAGS } from '@/config/featureFlags';
 
-import TablerDownloadOff from '~icons/tabler/download-off';
-import TablerDownload from '~icons/tabler/download';
+import TablerDownloadOff from '@/components/icons/TablerDownloadOff.vue';
+import TablerDownload from '@/components/icons/TablerDownload.vue';
+
 import ProiconsDelete from '~icons/proicons/delete';
 import CircumEdit from '~icons/circum/edit';
 

--- a/resources/js/components/menus/LibraryFolderCardMenu.vue
+++ b/resources/js/components/menus/LibraryFolderCardMenu.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ButtonText } from '@/components/cedar-ui/button';
+import { FLAGS } from '@/config/featureFlags';
 
 import ProiconsDelete from '~icons/proicons/delete';
 import ProiconsLock from '~icons/proicons/lock';
 import CircumEdit from '~icons/circum/edit';
-
 const props = withDefaults(defineProps<{ handleClosePopover?: () => void }>(), {});
 </script>
 
@@ -32,7 +32,7 @@ const props = withDefaults(defineProps<{ handleClosePopover?: () => void }>(), {
                 <p class="flex-1 text-start">Manage Metadata</p>
                 <template #icon> <ProiconsLock class="size-4" /></template>
             </ButtonText>
-            <ButtonText class="text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!" title="Remove From Server" disabled>
+            <ButtonText v-if="FLAGS.USE_REMOVABLE_FOLDERS" class="text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!" title="Remove From Server" disabled>
                 <p class="flex-1 text-start">Remove Folder</p>
                 <template #icon> <ProiconsDelete class="size-4" /></template>
             </ButtonText>

--- a/resources/js/components/menus/LibraryFolderCardMenu.vue
+++ b/resources/js/components/menus/LibraryFolderCardMenu.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
+import type { FolderResource } from '@/contracts/media';
+
 import { ButtonText } from '@/components/cedar-ui/button';
 import { FLAGS } from '@/config/featureFlags';
 
+import TablerDownloadOff from '~icons/tabler/download-off';
+import TablerDownload from '~icons/tabler/download';
 import ProiconsDelete from '~icons/proicons/delete';
-import ProiconsLock from '~icons/proicons/lock';
 import CircumEdit from '~icons/circum/edit';
-const props = withDefaults(defineProps<{ handleClosePopover?: () => void }>(), {});
+
+const props = withDefaults(
+    defineProps<{
+        handleClosePopover?: () => void;
+        data: FolderResource;
+        processing: boolean;
+        libraryDownloadsEnabled: boolean;
+        handleToggleDownloads: (id: number, currentValue: boolean) => Promise<void>;
+    }>(),
+    {},
+);
 </script>
 
 <template>
@@ -28,10 +41,17 @@ const props = withDefaults(defineProps<{ handleClosePopover?: () => void }>(), {
                 <p class="flex-1 text-start">Edit Folder</p>
                 <template #icon> <CircumEdit class="size-4" /></template>
             </ButtonText>
-            <ButtonText title="Manage Metadata Settings" disabled>
-                <p class="flex-1 text-start">Manage Metadata</p>
-                <template #icon> <ProiconsLock class="size-4" /></template>
+
+            <ButtonText
+                v-if="libraryDownloadsEnabled && data.series"
+                :title="'Toggle Downloads'"
+                @click="handleToggleDownloads(data.series.id, data.series.allow_downloads ?? false)"
+                :disabled="processing"
+            >
+                <p class="flex-1 text-start">{{ data.series?.allow_downloads ? 'Disable Downloads' : 'Enable Downloads' }}</p>
+                <template #icon> <TablerDownload v-if="data.series?.allow_downloads" class="size-4" /> <TablerDownloadOff v-else class="size-4" /></template>
             </ButtonText>
+
             <ButtonText v-if="FLAGS.USE_REMOVABLE_FOLDERS" class="text-danger dark:text-foreground-0 dark:bg-danger-3! dark:hocus:bg-danger!" title="Remove From Server" disabled>
                 <p class="flex-1 text-start">Remove Folder</p>
                 <template #icon> <ProiconsDelete class="size-4" /></template>

--- a/resources/js/components/video/VideoInfoPanel.vue
+++ b/resources/js/components/video/VideoInfoPanel.vue
@@ -64,8 +64,10 @@ const popoverItems = computed(() => {
         {
             icon: ProiconsArrowDownload,
             text: 'Download',
-            action: () => {},
-            disabled: true,
+            action: () => {
+                window.open(`/api/media/${stateVideo.value.id}/download`, '_blank');
+            },
+            disabled: false,
         },
         {
             icon: LucideCaptions,
@@ -187,7 +189,6 @@ onMounted(() => {
                     </h2>
                 </template>
             </HoverCard>
-
             <BasePopover
                 class="sm:hidden"
                 popoverClass="max-w-36 p-1 rounded-md shadow-xs"

--- a/resources/js/components/video/VideoInfoPanel.vue
+++ b/resources/js/components/video/VideoInfoPanel.vue
@@ -20,11 +20,11 @@ import { toast } from '@aminnausin/cedar-ui';
 
 import EditFolderModal from '@/components/modals/EditFolderModal.vue';
 import EditMediaModal from '@/components/modals/EditMediaModal.vue';
+import TablerDownload from '@/components/icons/TablerDownload.vue';
 import useMetaData from '@/composables/useMetaData';
 import ShareModal from '@/components/modals/ShareModal.vue';
 import LazyImage from '@/components/lazy/LazyImage.vue';
 
-import ProiconsArrowDownload from '~icons/proicons/arrow-download';
 import ProiconsMoreVertical from '~icons/proicons/more-vertical';
 import LucideCaptions from '~icons/lucide/captions';
 import CircumShare1 from '~icons/circum/share-1';
@@ -62,7 +62,7 @@ const popoverItems = computed(() => {
             action: handleShare,
         },
         {
-            icon: ProiconsArrowDownload,
+            icon: TablerDownload,
             text: 'Download',
             action: () => {
                 window.open(`/api/media/${stateVideo.value.id}/download`, '_blank');
@@ -294,11 +294,6 @@ onMounted(() => {
                     <ButtonText v-if="userData" aria-label="edit details" title="Edit Metadata" @click="handleEdit">
                         <p class="text-nowrap">Edit Metadata</p>
                     </ButtonText>
-                    <ButtonIcon aria-label="download" :title="`Download ${mediaTypeDescription}`" class="hidden">
-                        <template #icon>
-                            <ProiconsArrowDownload height="16" width="16" />
-                        </template>
-                    </ButtonIcon>
 
                     <BasePopover
                         class="hidden sm:block"

--- a/resources/js/components/video/VideoInfoPanel.vue
+++ b/resources/js/components/video/VideoInfoPanel.vue
@@ -327,7 +327,7 @@ onMounted(() => {
             <article :class="['text-foreground-1 flex w-full flex-1 flex-col justify-between gap-1', { 'max-h-32': !isExpanded }]">
                 <div
                     :class="[
-                        'scrollbar-minimal scrollbar-hover overflow-x-clip overflow-y-auto whitespace-pre-wrap',
+                        'overflow-clip whitespace-pre-wrap',
                         { 'h-20 sm:h-10': !isExpanded && isOverflowing }, // h-16 and 2.5rem on big screens if show more button exists and not expanded
                         { 'h-25.5 sm:h-15': !isExpanded && !isOverflowing }, // otherwise, fill space... I think this makes sense?
                     ]"

--- a/resources/js/config/featureFlags.ts
+++ b/resources/js/config/featureFlags.ts
@@ -1,4 +1,6 @@
 export const FLAGS = {
     USE_TOGGLE_FOLDER_FILTERS: false,
     FORCE_MODERN_PLAYER_UI: true,
+    USE_REMOVABLE_LIBRARIES: false,
+    USE_REMOVABLE_FOLDERS: false,
 };

--- a/resources/js/contracts/media.ts
+++ b/resources/js/contracts/media.ts
@@ -12,6 +12,8 @@ export interface CategoryResource {
     created_at?: string;
     last_scan: number;
     is_private?: boolean;
+    allow_downloads: boolean;
+    require_login_for_downloads: boolean;
 }
 
 //#region Folders
@@ -54,6 +56,7 @@ export interface SeriesResource {
     created_at?: string;
     updated_at?: string;
     edited_at?: string;
+    allow_downloads: boolean;
 }
 
 //#endregion

--- a/resources/js/contracts/media.ts
+++ b/resources/js/contracts/media.ts
@@ -12,8 +12,8 @@ export interface CategoryResource {
     created_at?: string;
     last_scan: number;
     is_private?: boolean;
-    allow_downloads: boolean;
-    require_login_for_downloads: boolean;
+    downloads_enabled: boolean;
+    downloads_require_auth: boolean;
 }
 
 //#region Folders
@@ -56,7 +56,7 @@ export interface SeriesResource {
     created_at?: string;
     updated_at?: string;
     edited_at?: string;
-    allow_downloads: boolean;
+    downloads_enabled: boolean;
 }
 
 //#endregion

--- a/resources/js/service/siteAPI.ts
+++ b/resources/js/service/siteAPI.ts
@@ -41,8 +41,16 @@ export function getTaskWaitTimes() {
     return API.get('/tasks/wait-times');
 }
 
-export function toggleCategoryPrivacy(category: number, value: boolean) {
-    return API.post(`/categories/privacy/${category}`, { is_private: value });
+export function toggleCategoryPrivacy(id: number, value: boolean) {
+    return API.post(`/categories/${id}/privacy/`, { is_private: value });
+}
+
+export function setLibraryDownloadSettings(id: number, data: { allow_downloads?: boolean; require_login_for_downloads?: boolean }) {
+    return API.put(`/categories/${id}/downloads`, data);
+}
+
+export function setSeriesDownloadSettings(id: number, data: { allow_downloads?: boolean }) {
+    return API.put(`/series/${id}/downloads`, data);
 }
 
 export function startGenericTast(url: string) {

--- a/resources/js/service/siteAPI.ts
+++ b/resources/js/service/siteAPI.ts
@@ -45,11 +45,11 @@ export function toggleCategoryPrivacy(id: number, value: boolean) {
     return API.post(`/categories/${id}/privacy/`, { is_private: value });
 }
 
-export function setLibraryDownloadSettings(id: number, data: { allow_downloads?: boolean; require_login_for_downloads?: boolean }) {
+export function setLibraryDownloadSettings(id: number, data: { downloads_enabled?: boolean; downloads_require_auth?: boolean }) {
     return API.put(`/categories/${id}/downloads`, data);
 }
 
-export function setSeriesDownloadSettings(id: number, data: { allow_downloads?: boolean }) {
+export function setSeriesDownloadSettings(id: number, data: { downloads_enabled?: boolean }) {
     return API.put(`/series/${id}/downloads`, data);
 }
 

--- a/resources/js/stores/ContentStore.ts
+++ b/resources/js/stores/ContentStore.ts
@@ -15,7 +15,16 @@ import mediaAPI from '@/service/mediaAPI.ts';
 // dir: {id: 1, name: 'anime', folders: ["id": "6", "name": "Frieren", "path": "anime/Frieren", "file_count": 28, "category_id": "1","series": null] } -> api/categories/1 -> folders dont hold video data
 // folder: {id: 11, name: 'BOCCHI THE ROCK', videos: [id, name, pat, date, metadata], series: {}}
 
-const emptyLibrary: CategoryResource = { id: 0, name: '', folders: [], folders_count: 0, total_size: 0, last_scan: -1 };
+const emptyLibrary: CategoryResource = {
+    id: 0,
+    name: '',
+    folders: [],
+    folders_count: 0,
+    total_size: 0,
+    last_scan: -1,
+    downloads_enabled: false,
+    downloads_require_auth: false,
+};
 const emptyFolder: FolderResource = { id: 0, name: '', title: '', path: '', file_count: 0, total_size: 0, is_majority_audio: false, category_id: 0, videos: [], last_scan: -1 };
 const emptyMedia: VideoResource = { id: 0, name: '', path: '', view_count: 0, video_tags: [], created_at: '', subtitles: [] };
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,11 +66,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::resource('/series', SeriesController::class)->only(['index', 'store', 'update']);
     Route::resource('/tags', TagController::class)->only(['index', 'store']);
 
-    Route::prefix('/media/{video}')->group(function () {
-        // Downloads
-        Route::get('/download', [MediaController::class, 'download']);
-    });
-
     Route::prefix('/metadata/{metadata}')->group(function () {
         // Lyrics
         Route::patch('/lyrics', [MetadataController::class, 'updateLyrics']);
@@ -150,6 +145,12 @@ Route::get('/videos', [VideoController::class, 'getFrom']);
 
 // Video playback history
 Route::resource('/playback', PlaybackController::class)->only(['show', 'store']);
+
+// Media Specific
+Route::prefix('/media/{video}')->group(function () {
+    // Downloads
+    Route::get('/download', [MediaController::class, 'download']);
+});
 
 // Lyrics Service
 Route::get('/metadata/{id}/lyrics/import', [ExternalMetadataController::class, 'importLyrics']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,7 +44,7 @@ Route::prefix('pulse')->group(function () {
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
     // Auth
-    Route::get('/user', fn(Request $request) => $request->user());
+    Route::get('/user', fn (Request $request) => $request->user());
     Route::delete('/logout', [AuthController::class, 'destroy']);
 
     // Settings
@@ -87,7 +87,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         // Download Access Control
         Route::put('/downloads', [CategoryController::class, 'updateDownloadSettings']);
     });
-
 
     Route::prefix('/series/{series}')->group(function () {
         // Download Access Control
@@ -135,8 +134,8 @@ Route::post('/recovery', [PasswordResetLinkController::class, 'store'])->name('p
 Route::post('/reset-password/{token}', [PasswordController::class, 'store'])->name('password.reset');
 
 // App Info
-Route::get('/manifest', fn() => response()->json(AppManifest::info()));
-Route::get('/health', fn() => response()->json(['health' => 1]));
+Route::get('/manifest', fn () => response()->json(AppManifest::info()));
+Route::get('/health', fn () => response()->json(['health' => 1]));
 
 // Libraries (categories)
 Route::resource('/categories', CategoryController::class)->only(['index', 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,7 +44,7 @@ Route::prefix('pulse')->group(function () {
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
     // Auth
-    Route::get('/user', fn (Request $request) => $request->user());
+    Route::get('/user', fn(Request $request) => $request->user());
     Route::delete('/logout', [AuthController::class, 'destroy']);
 
     // Settings
@@ -81,6 +81,19 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::put('/progress', [PlaybackProgressController::class, 'upsert']);
     });
 
+    Route::prefix('/categories/{category}')->group(function () {
+        // Access Control
+        Route::post('/privacy', [CategoryController::class, 'updatePrivacySettings']);
+        // Download Access Control
+        Route::put('/downloads', [CategoryController::class, 'updateDownloadSettings']);
+    });
+
+
+    Route::prefix('/series/{series}')->group(function () {
+        // Download Access Control
+        Route::put('/downloads', [SeriesController::class, 'updateDownloadSettings']);
+    });
+
     // Users and Profiles
     Route::get('/profiles/search/{username?}', [ProfileController::class, 'findUser']);
     Route::resource('/users', UserController::class)->only(['index', 'destroy']);
@@ -96,7 +109,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::resource('/analytics', AnalyticsController::class)->only(['index']);
 
     Route::post('/sub-tasks/{task}', [SubTaskController::class, 'show']);
-    Route::post('/categories/privacy/{category}', [CategoryController::class, 'updatePrivacy']);
 
     Route::prefix('tasks')->group(function () {
         Route::get('/stats', [TaskController::class, 'stats']);
@@ -123,8 +135,8 @@ Route::post('/recovery', [PasswordResetLinkController::class, 'store'])->name('p
 Route::post('/reset-password/{token}', [PasswordController::class, 'store'])->name('password.reset');
 
 // App Info
-Route::get('/manifest', fn () => response()->json(AppManifest::info()));
-Route::get('/health', fn () => response()->json(['health' => 1]));
+Route::get('/manifest', fn() => response()->json(AppManifest::info()));
+Route::get('/health', fn() => response()->json(['health' => 1]));
 
 // Libraries (categories)
 Route::resource('/categories', CategoryController::class)->only(['index', 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\EmailController;
 use App\Http\Controllers\Api\V1\ExternalMetadataController;
 use App\Http\Controllers\Api\V1\FolderController;
 use App\Http\Controllers\Api\V1\JobController;
+use App\Http\Controllers\Api\V1\Media\MediaController;
 use App\Http\Controllers\Api\V1\Metadata\SubtitleController;
 use App\Http\Controllers\Api\V1\MetadataController;
 use App\Http\Controllers\Api\V1\PasswordController;
@@ -64,6 +65,11 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::resource('/metadata', MetadataController::class)->only(['show', 'store', 'update']);
     Route::resource('/series', SeriesController::class)->only(['index', 'store', 'update']);
     Route::resource('/tags', TagController::class)->only(['index', 'store']);
+
+    Route::prefix('/media/{video}')->group(function () {
+        // Downloads
+        Route::get('/download', [MediaController::class, 'download']);
+    });
 
     Route::prefix('/metadata/{metadata}')->group(function () {
         // Lyrics

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Http\Controllers\Api\V1\Media\MediaController;
 use App\Http\Controllers\Api\V1\Metadata\SubtitleController;
-use App\Http\Controllers\MediaController;
 use App\Http\Middleware\MetadataSSR;
 use App\Models\Category;
 use App\Models\Folder;


### PR DESCRIPTION
### Fixes

- Scan and download icon issues

### Changes

- Library card on dashboard links directly to the library/folder management page instead of going to the library's default folder

### Additions

- Closes #185 
- Includes Library and Folder level control for downloads
    - Library downloads are disabled by default
    - Folder downloads are enabled by default and only apply if their library's downloads are enabled
    - The private/guest downloads settings determine if users must be logged in to download files
- All download activity is logged through the default Laravel logger, with detailed user and file information
- Max download size is controlled by `MAX_DOWNLOAD_SIZE_MB` in `.env` via `media.php` config

### Demo

- Download from player menu
  <img width="258" height="178" alt="image" src="https://github.com/user-attachments/assets/ab543a3e-76d3-45e4-b207-3d31778b0f27" />

- Library level download settings
  <img width="267" height="359" alt="image" src="https://github.com/user-attachments/assets/4c603eb6-6fa1-4b7a-ac86-78fb861b25d3" />
  
- Folder level download settings
  <img width="425" height="395" alt="image" src="https://github.com/user-attachments/assets/0eb5799d-5f8d-4b2d-9fbb-ab351c962732" />


