### PR TITLE
Fix/metadata tags missing

### DIFF
--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -61,6 +61,13 @@ class MetadataController extends Controller {
         if ($metadata->isDirty() || $tagsChanged) {
             $metadata->fill(['editor_id' => Auth::id(), 'edited_at' => now()]);
 
+            Log::info('Metadata edited', [
+                'diff' => collect($metadata->getDirty())->map(function ($new, $field) use ($metadata) {
+                    return "{$field}: '{$metadata->getOriginal($field)}' → '{$new}'";
+                })->values()->toArray(),
+                'tags_changed' => $tagsChanged,
+            ]);
+
             $metadata->save();
         }
 

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -54,18 +54,23 @@ class MetadataController extends Controller {
      */
     public function update(MetadataUpdateRequest $request, Metadata $metadata) {
         $validated = $request->validated();
+        $metadata->fill($validated);
 
-        $validated['editor_id'] = Auth::id();
-        $validated['edited_at'] = now();
-        $metadata->update($validated);
+        $tagsChanged = $this->generateTagRelationships($metadata->id, $request->video_tags, $request->deleted_tags, 'metadata_id', VideoTag::class);
 
-        $this->generateTagRelationships($metadata->id, $request->video_tags, $request->deleted_tags, 'metadata_id', VideoTag::class);
+        if ($metadata->isDirty() || $tagsChanged) {
+            $metadata->fill(['editor_id' => Auth::id(), 'edited_at' => now()]);
+
+            $metadata->save();
+        }
 
         try {
             $video = Video::findOrFail($metadata->video_id);
+
             return response()->json(new VideoResource($this->eagerLoadVideo($video)));
         } catch (ModelNotFoundException $_) {
-            Log::warning("Media not found when submitting metadata edit", ["metadata_id" => $metadata->id, "video_id" => $metadata->video_id, "composite_id" => $metadata->composite_id]);
+            Log::warning('Media not found when submitting metadata edit', ['metadata_id' => $metadata->id, 'video_id' => $metadata->video_id, 'composite_id' => $metadata->composite_id]);
+
             return response()->noContent();
         } catch (\Exception $th) {
             return $this->error($request, 'Unable to update metadata. Error: ' . $th->getMessage(), 500);
@@ -84,6 +89,7 @@ class MetadataController extends Controller {
         $metadata->update($validated);
 
         $video = Video::findOrFail($metadata->video_id);
+
         return response()->json(new VideoResource($this->eagerLoadVideo($video)));
     }
 

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -17,7 +17,6 @@ use App\Traits\HttpResponses;
 use App\Traits\LogsModelChanges;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 
 class MetadataController extends Controller {
     use HasTags;
@@ -56,6 +55,8 @@ class MetadataController extends Controller {
      * Update the specified resource in storage.
      */
     public function update(MetadataUpdateRequest $request, Metadata $metadata) {
+        $video = Video::findOrFail($metadata->video_id);
+
         $validated = $request->validated();
         $metadata->fill($validated);
 
@@ -69,17 +70,7 @@ class MetadataController extends Controller {
             $metadata->save();
         }
 
-        try {
-            $video = Video::findOrFail($metadata->video_id);
-
-            return response()->json(new VideoResource($this->eagerLoadVideo($video)));
-        } catch (ModelNotFoundException $_) {
-            Log::warning('Media not found when submitting metadata edit', ['metadata_id' => $metadata->id, 'video_id' => $metadata->video_id, 'composite_id' => $metadata->composite_id]);
-
-            return response()->noContent();
-        } catch (\Exception $th) {
-            return $this->error($request, 'Unable to update metadata. Error: ' . $th->getMessage(), 500);
-        }
+        return response()->json(new VideoResource($this->eagerLoadVideo($video)));
     }
 
     public function updateLyrics(LyricsUpdateRequest $request, Metadata $metadata) {

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -13,6 +13,7 @@ use App\Models\Video;
 use App\Models\VideoTag;
 use App\Traits\HasTags;
 use App\Traits\HttpResponses;
+use App\Traits\LogsModelChanges;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -20,6 +21,7 @@ use Illuminate\Support\Facades\Log;
 class MetadataController extends Controller {
     use HasTags;
     use HttpResponses;
+    use LogsModelChanges;
 
     public function show($id) {
         $metadata = Metadata::with(['videoTags.tag'])->findOrFail($id);
@@ -61,12 +63,7 @@ class MetadataController extends Controller {
         if ($metadata->isDirty() || $tagsChanged) {
             $metadata->fill(['editor_id' => Auth::id(), 'edited_at' => now()]);
 
-            Log::info('Metadata edited', [
-                'diff' => collect($metadata->getDirty())->map(function ($new, $field) use ($metadata) {
-                    return "{$field}: '{$metadata->getOriginal($field)}' → '{$new}'";
-                })->values()->toArray(),
-                'tags_changed' => $tagsChanged,
-            ]);
+            $this->logModelChanges($metadata, ['tags_changed' => $tagsChanged]);
 
             $metadata->save();
         }
@@ -91,9 +88,14 @@ class MetadataController extends Controller {
 
         $validated = $request->validated();
         $validated['title'] = $validated['track']; // ?? Track is unused ? I think this is by design? The title is displayed in more places than just the lyrics editor so it should not be changed by the external api.
-        $validated['editor_id'] = Auth::id();
-        $validated['edited_at'] = now();
-        $metadata->update($validated);
+
+        $metadata->fill($validated);
+
+        if ($metadata->isDirty()) {
+            $metadata->fill(['editor_id' => Auth::id(), 'edited_at' => now()]);
+            $this->logModelChanges($metadata);
+            $metadata->save();
+        }
 
         $video = Video::findOrFail($metadata->video_id);
 

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -11,21 +11,20 @@ use App\Http\Resources\VideoResource;
 use App\Models\Metadata;
 use App\Models\Video;
 use App\Models\VideoTag;
-use App\Traits\HasModelHelpers;
 use App\Traits\HasTags;
 use App\Traits\HttpResponses;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 
 class MetadataController extends Controller {
-    use HasModelHelpers;
     use HasTags;
     use HttpResponses;
 
     public function show($id) {
         $metadata = Metadata::with(['videoTags.tag'])->findOrFail($id);
 
-        return $this->success(new MetadataResource($metadata));
+        return response()->json(new MetadataResource($metadata));
     }
 
     /**
@@ -36,23 +35,18 @@ class MetadataController extends Controller {
 
         $video = Video::findOrFail($validated['video_id']);
 
-        $compositeId = $video->folder->path . '/' . basename($video->path);
-        $existing = Metadata::where('composite_id', $compositeId)->first();
-        if ($this->conflictsWithAnother('video_id', $existing, $validated['video_id'])) {
-            return $this->error($existing, 'Metadata with generated unique id already exists for another media!', 500);
-        }
-
         $validated['editor_id'] = Auth::id();
         $validated['edited_at'] = now();
-        $validated['composite_id'] = $compositeId;
+        $validated['composite_id'] = $video->composite_id;
 
-        $metadata = $existing
-            ? $this->updateExisting($existing, $validated)
-            : Metadata::create($validated);
+        $metadata = Metadata::updateOrCreate(
+            ['composite_id' => $validated['composite_id']],
+            $validated
+        );
 
         $this->generateTagRelationships($metadata->id, $request->video_tags, $request->deleted_tags, 'metadata_id', VideoTag::class);
 
-        return response()->json(new VideoResource($metadata->video));
+        return response()->json(new VideoResource($this->eagerLoadVideo($video)));
     }
 
     /**
@@ -67,25 +61,33 @@ class MetadataController extends Controller {
 
         $this->generateTagRelationships($metadata->id, $request->video_tags, $request->deleted_tags, 'metadata_id', VideoTag::class);
 
-        return response()->json(new VideoResource($metadata->video));
+        try {
+            $video = Video::findOrFail($metadata->video_id);
+            return response()->json(new VideoResource($this->eagerLoadVideo($video)));
+        } catch (ModelNotFoundException $_) {
+            Log::warning("Media not found when submitting metadata edit", ["metadata_id" => $metadata->id, "video_id" => $metadata->video_id, "composite_id" => $metadata->composite_id]);
+            return response()->noContent();
+        } catch (\Exception $th) {
+            return $this->error($request, 'Unable to update metadata. Error: ' . $th->getMessage(), 500);
+        }
     }
 
     public function updateLyrics(LyricsUpdateRequest $request, Metadata $metadata) {
-        try {
-            $validated = $request->validated();
-
-            if (empty($metadata->video)) {
-                throw new ModelNotFoundException('Song does not exist');
-            }
-
-            $validated['title'] = $validated['track']; // ?? Track is unused ? I think this is by design? The title is displayed in more places than just the lyrics editor so it should not be changed by the external api.
-            $validated['editor_id'] = Auth::id();
-            $validated['edited_at'] = now();
-            $metadata->update($validated);
-
-            return response()->json(new VideoResource($metadata->video));
-        } catch (\Throwable $th) {
-            return $this->error($request, 'Unable to edit song. Error: ' . $th->getMessage(), 500);
+        if ($metadata->video_id === null) {
+            throw new ModelNotFoundException('Song does not exist');
         }
+
+        $validated = $request->validated();
+        $validated['title'] = $validated['track']; // ?? Track is unused ? I think this is by design? The title is displayed in more places than just the lyrics editor so it should not be changed by the external api.
+        $validated['editor_id'] = Auth::id();
+        $validated['edited_at'] = now();
+        $metadata->update($validated);
+
+        $video = Video::findOrFail($metadata->video_id);
+        return response()->json(new VideoResource($this->eagerLoadVideo($video)));
+    }
+
+    private function eagerLoadVideo(Video $video): Video {
+        return $video->load(['metadata', 'metadata.subtitles', 'metadata.videoTags']);
     }
 }

--- a/app/Http/Controllers/Api/V1/MetadataController.php
+++ b/app/Http/Controllers/Api/V1/MetadataController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\MetadataUpdateRequest;
 use App\Http\Resources\MetadataResource;
 use App\Http\Resources\VideoResource;
 use App\Models\Metadata;
+use App\Models\Subtitle;
 use App\Models\Video;
 use App\Models\VideoTag;
 use App\Traits\HasTags;
@@ -103,6 +104,12 @@ class MetadataController extends Controller {
     }
 
     private function eagerLoadVideo(Video $video): Video {
-        return $video->load(['metadata', 'metadata.subtitles', 'metadata.videoTags']);
+        return $video->load([
+            'metadata',
+            'metadata.subtitles' => function ($q) {
+                $q->select(Subtitle::getVisibleFields());
+            },
+            'metadata.videoTags',
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/VideoController.php
+++ b/app/Http/Controllers/Api/V1/VideoController.php
@@ -20,7 +20,7 @@ class VideoController extends Controller {
      */
     public function getFrom(VideoCollectionRequest $request) {
         try {
-            $result = VideoResource::collection(Video::where('folder_id', $request->folder_id)->get());
+            $result = VideoResource::collection(Video::with(['metadata', 'metadata.subtitles', 'metadata.videoTags'])->where('folder_id', $request->folder_id)->get());
 
             return $this->success($result);
         } catch (\Throwable $th) {

--- a/app/Http/Resources/MetadataResource.php
+++ b/app/Http/Resources/MetadataResource.php
@@ -20,6 +20,8 @@ class MetadataResource extends JsonResource {
             'editor_id' => $this->editor_id,
 
             'title' => $this->title,
+            'artist' => $this?->artist,
+            'album' => $this?->album,
             'lyrics' => $this->lyrics,
 
             'poster_url' => $this->poster_url,

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -12,15 +12,25 @@ class VideoResource extends JsonResource {
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array {
-        if (! $this->relationLoaded('metadata')) {
-            $this->loadMissing('metadata');
-        }
-
-        if (! $this->relationLoaded('metadata.subtitles')) {
-            $this->loadMissing('metadata.subtitles');
-        }
+        throw_unless(
+            $this->relationLoaded('metadata'),
+            \RuntimeException::class,
+            'VideoResource requires metadata relation to be eager-loaded.'
+        );
 
         $metadata = $this->metadata;
+
+        throw_if(
+            $metadata && ! $metadata->relationLoaded('subtitles'),
+            \RuntimeException::class,
+            'VideoResource requires metadata.subtitles relation to be eager-loaded.'
+        );
+
+        throw_if(
+            $metadata && ! $metadata->relationLoaded('videoTags'),
+            \RuntimeException::class,
+            'VideoResource requires metadata.videoTags relation to be eager-loaded.'
+        );
 
         return [
             'id' => $this->id,
@@ -34,11 +44,11 @@ class VideoResource extends JsonResource {
             'season' => $metadata?->season,
             'artist' => $metadata?->artist,
             'album' => $metadata?->album,
-            'intro_start' => $metadata->intro_start,
-            'intro_duration' => $metadata->intro_duration,
+            'intro_start' => $metadata?->intro_start,
+            'intro_duration' => $metadata?->intro_duration,
 
-            'video_tags' => VideoTagResource::collection($this->relationLoaded('metadata.videoTags') ? $metadata->videoTags : []),
-            'subtitles' => SubtitleResource::collection($metadata->subtitles ?? []),
+            'video_tags' => VideoTagResource::collection($metadata?->videoTags ?? []),
+            'subtitles' => SubtitleResource::collection($metadata?->subtitles ?? []),
 
             'view_count' => $metadata?->view_count ?? 0,
 

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -20,18 +20,6 @@ class VideoResource extends JsonResource {
 
         $metadata = $this->metadata;
 
-        throw_if(
-            $metadata && ! $metadata->relationLoaded('subtitles'),
-            \RuntimeException::class,
-            'VideoResource requires metadata.subtitles relation to be eager-loaded.'
-        );
-
-        throw_if(
-            $metadata && ! $metadata->relationLoaded('videoTags'),
-            \RuntimeException::class,
-            'VideoResource requires metadata.videoTags relation to be eager-loaded.'
-        );
-
         return [
             'id' => $this->id,
             'name' => $this->name,
@@ -47,8 +35,8 @@ class VideoResource extends JsonResource {
             'intro_start' => $metadata?->intro_start,
             'intro_duration' => $metadata?->intro_duration,
 
-            'video_tags' => VideoTagResource::collection($metadata?->videoTags ?? []),
-            'subtitles' => SubtitleResource::collection($metadata?->subtitles ?? []),
+            'video_tags' => VideoTagResource::collection($metadata?->relationLoaded('videoTags') ? $metadata->videoTags : []),
+            'subtitles' => SubtitleResource::collection($metadata?->relationLoaded('subtitles') ? $metadata->subtitles : []),
 
             'view_count' => $metadata?->view_count ?? 0,
 

--- a/app/Models/Metadata.php
+++ b/app/Models/Metadata.php
@@ -15,8 +15,8 @@ class Metadata extends Model {
 
     /**
      * id                   -> int8 (pk) (index)
-     * video_id             -> int8 (fk) (index) (nullable)
-     * composite_id         -> varchar(255) (index)
+     * video_id             -> int8 (fk) (index) (nullable) (unique)
+     * composite_id         -> varchar(255) (index) (unique)
      *
      * title                -> varchar(255) (nullable)
      * season               -> int4 (nullable)
@@ -29,7 +29,7 @@ class Metadata extends Model {
      * editor_id            -> int8 (fk) (nullable)
      * created_at           -> timestamp (nullable)
      * updated_at           -> timestamp (nullable)
-     * uuid                 -> uuid (index) (nullable)
+     * uuid                 -> uuid (index) (nullable) (unique)
      *
      * file_size            -> int8 (nullable)
      * poster_url           -> text (nullable)

--- a/app/Models/Metadata.php
+++ b/app/Models/Metadata.php
@@ -111,6 +111,9 @@ class Metadata extends Model {
     protected $guarded = ['logical_composite_id'];
 
     protected $casts = [
+        'episode' => 'integer',
+        'season' => 'integer',
+
         'file_scanned_at' => 'datetime',
         'file_modified_at' => 'datetime',
         'first_file_modified_at' => 'datetime',

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Str;
 
 class Video extends Model {
     use HasFactory;
@@ -53,5 +54,9 @@ class Video extends Model {
 
     public function downloadsEnabled(): bool {
         return $this->folder?->downloadsEnabled() ?? false;
+    }
+
+    public function getCompositeIdAttribute(): string {
+        return Str::after($this->path, config('media.storage.prefix', 'storage/media/'));
     }
 }

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -118,7 +118,7 @@ class PreviewGeneratorService {
     protected function buildVideoPreviewData(Category $category, ?Folder $folder, string $videoId, Request $request, bool $generateRawPreview): array {
         $folderResource = $this->getDecodedResource(new FolderResource($folder));
         $video = $folder->videos()->findOrFail($videoId);
-        $videoResource = $this->getDecodedResource(new VideoResource($video));
+        $videoResource = $this->getDecodedResource(new VideoResource($video->load('metadata.videoTags')));
 
         $isAudio = str_starts_with($videoResource->metadata?->mime_type, 'audio');
         $thumbnail = $videoResource->metadata->poster_url ?: $folder->series->thumbnail_url ?: $this->defaultThumbnail;

--- a/app/Traits/HasTags.php
+++ b/app/Traits/HasTags.php
@@ -39,10 +39,6 @@ trait HasTags {
                 $modelClass::destroy($deletedTags);
             }
 
-            if ($newTags->isNotEmpty() || ! empty($deletedTags)) {
-                Log::info('dirty tags', [$existingIds, $newTags, $tags, $deletedTags]);
-            }
-
             return $newTags->isNotEmpty() || ! empty($deletedTags);
         } catch (\Throwable $th) {
             Log::error('Failed creating/deleting tag relationships', [

--- a/app/Traits/HasTags.php
+++ b/app/Traits/HasTags.php
@@ -8,11 +8,11 @@ trait HasTags {
     /**
      * Generates tag relationships for any model
      *
-     * @param  int  $relationId  Related model Id (metadata_id, series_id)
-     * @param  array  $tags  New Tags
-     * @param  array  $deletedTags  Deleted Tag Relationship Ids
-     * @param  string  $foreignKey  Related Foreign Key
-     * @param  string  $modelClass  Related Model Class
+     * @param  int  $relationId  Related model id (metadata->id, series->id)
+     * @param  array  $tags  New tags
+     * @param  array  $deletedTags  Deleted tag relationship ids
+     * @param  string  $foreignKey  Related foreign key name ('metadata_id')
+     * @param  string  $modelClass  Related tag model class
      */
     public function generateTagRelationships(
         int $relationId,
@@ -20,21 +20,39 @@ trait HasTags {
         array $deletedTags,
         string $foreignKey,
         string $modelClass
-    ) {
+    ): bool {
         try {
-            foreach ($tags as $tag) {
-                $modelClass::firstOrCreate([
-                    'tag_id' => $tag['id'],
-                    $foreignKey => $relationId,
-                ]);
+            $existingIds = $modelClass::where($foreignKey, $relationId)->pluck('tag_id');
+            $newTags = collect($tags)->pluck('id')->diff($existingIds);
+
+            if ($newTags->isNotEmpty()) {
+                $modelClass::upsert(
+                    $newTags->map(fn ($tagId) => [
+                        'tag_id' => $tagId,
+                        $foreignKey => $relationId,
+                    ])->toArray(),
+                    ['tag_id', $foreignKey]
+                );
             }
 
-            $modelClass::destroy($deletedTags);
+            if (! empty($deletedTags)) {
+                $modelClass::destroy($deletedTags);
+            }
+
+            if ($newTags->isNotEmpty() || ! empty($deletedTags)) {
+                Log::info('dirty tags', [$existingIds, $newTags, $tags, $deletedTags]);
+            }
+
+            return $newTags->isNotEmpty() || ! empty($deletedTags);
         } catch (\Throwable $th) {
-            Log::error('Faild creating/deleting tag relationships', [
+            Log::error('Failed creating/deleting tag relationships', [
+                'model' => $modelClass,
+                'fk' => $foreignKey,
                 'error' => $th->getMessage(),
                 'trace' => $th->getTraceAsString(),
             ]);
+
+            throw $th;
         }
     }
 }

--- a/app/Traits/LogsModelChanges.php
+++ b/app/Traits/LogsModelChanges.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+
+trait LogsModelChanges {
+    protected function logModelChanges(Model $model, array $context = []): void {
+        $diff = collect($model->getDirty())->map(
+            fn ($new, $field) => "{$field}: '{$model->getOriginal($field)}' → '{$new}'"
+        )->values()->toArray();
+
+        Log::info(class_basename($model) . ' changed by user', [
+            'id' => $model->getKey(),
+            'diff' => $diff,
+            ...$context,
+        ]);
+    }
+}

--- a/config/media.php
+++ b/config/media.php
@@ -6,5 +6,5 @@ return [
     ],
     'storage' => [
         'prefix' => 'storage/media/',
-    ]
+    ],
 ];

--- a/config/media.php
+++ b/config/media.php
@@ -4,4 +4,7 @@ return [
     'downloads' => [
         'max_size_mb' => env('MAX_DOWNLOAD_SIZE_MB', 1024 * 6),
     ],
+    'storage' => [
+        'prefix' => 'storage/media/',
+    ]
 ];

--- a/tests/Feature/MetadataControllerTest.php
+++ b/tests/Feature/MetadataControllerTest.php
@@ -87,7 +87,7 @@ class MetadataControllerTest extends TestCase {
         ];
 
         $this->patchJson("/api/metadata/{$metadata->id}/lyrics", $payload)
-            ->assertStatus(500)
-            ->assertJsonPath('message', 'Unable to edit song. Error: Song does not exist');
+            ->assertStatus(404)
+            ->assertJsonPath('message', 'Song does not exist');
     }
 }


### PR DESCRIPTION
### Fixes

- Closes #282 
- Applies fix only for `metadata` for #276 
- Album and artist were loaded in the editor UI from `MetadataResource` but those values were moved to `VideoResource` (re-added for now)
- Eager loading was not correctly handled for `video.metadata.subtitles` and `video.metadata.videoTags` in `VideoResource` 
    - they are still optional but don't run queries if not loaded
    - Eager loading for `video.metadata` is hard enforced
- Season and Episode values were not casted to integer and were always dirty on metadata updates
- Tag relationship generator had n+1 queries

### Additions

- Logs diff on edit of metadata or lyrics
- `media.storage.prefix` config option used for building `composite_id` without `folder`
    - Defaults to `storage/media/`

### Demo

- Edit diff 
  <img width="518" height="243" alt="image" src="https://github.com/user-attachments/assets/ec769105-ec05-4b82-a906-5ddf0aebb41c" />

