### PR TITLE
Feat/guest progress

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/GuestTokenController.php
+++ b/app/Http/Controllers/Api/V1/Auth/GuestTokenController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
+
+class GuestTokenController extends Controller {
+    public function issue(): JsonResponse {
+        return response()->json(['token' => (string) Str::uuid()]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UserLoginRequest;
 use App\Http\Requests\UserStoreRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
+use App\Services\Auth\GuestMergeService;
 use App\Traits\HttpResponses;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -14,6 +15,8 @@ use Illuminate\Support\Facades\Hash;
 
 class AuthController extends Controller {
     use HttpResponses;
+
+    public function __construct(private readonly GuestMergeService $guestMergeService) {}
 
     /**
      * Attempt to authenticate the request's credentials_me.
@@ -27,6 +30,8 @@ class AuthController extends Controller {
 
         $user = User::where('email', $validated['email'])->first(); // Should remove
         $token = $user->createToken('API token for ' . $user->name)->plainTextToken; // Should remove
+
+        $this->guestMergeService->merge($user, $request->header('X-Guest-Token'));
 
         $request->session()->regenerate();
 
@@ -44,6 +49,8 @@ class AuthController extends Controller {
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
         ]);
+
+        $this->guestMergeService->merge($user, $request->header('X-Guest-Token'));
 
         if ($request->expectsJson()) {
             Auth::login($user);

--- a/app/Http/Controllers/Api/V1/ExternalMetadataController.php
+++ b/app/Http/Controllers/Api/V1/ExternalMetadataController.php
@@ -10,15 +10,11 @@ use Illuminate\Http\Request;
 class ExternalMetadataController extends Controller {
     public function __construct(protected LrcLibService $lrcLibService) {}
 
-    public function importLyrics(Request $request, $id) {
-        $metadata = Metadata::FindOrFail($id);
-
+    public function importLyrics(Metadata $metadata) {
         return response()->json($this->lrcLibService->importLyrics($metadata));
     }
 
-    public function searchLyrics(Request $request, $id) {
-        $metadata = Metadata::FindOrFail($id);
-
+    public function searchLyrics(Request $request, Metadata $metadata) {
         return response()->json($this->lrcLibService->searchLyrics($metadata, $request));
     }
 }

--- a/app/Http/Controllers/Api/V1/PlaybackProgressController.php
+++ b/app/Http/Controllers/Api/V1/PlaybackProgressController.php
@@ -54,36 +54,27 @@ class PlaybackProgressController extends Controller {
                 $progress->record_id = $validated['record_id'] ?? $progress->record_id;
 
                 $progress->save();
-            } else {
-                GuestIdentity::upsert(
-                    'playback_progress',
-                    [
-                        ...$identity,
-                        'metadata_id' => $metadata->id,
-                        'progress_offset' => $progressOffset,
-                        'progress_percentage' => $progressPct,
-                        'record_id' => $validated['record_id'] ?? null,
-                        'created_at' => now(),
-                        'updated_at' => now(),
-                    ],
-                    ['progress_offset', 'progress_percentage', 'record_id', 'updated_at']
-                );
 
-                // PlaybackProgress::upsert(
-                //     [
-                //         ...$identity,
-                //         'metadata_id' => $metadata->id,
-                //         'progress_offset' => $progressOffset,
-                //         'progress_percentage' => $progressPct,
-                //         'record_id' => $validated['record_id'] ?? null, // Overwrites existing
-                //         'updated_at' => now(),
-                //     ],
-                //     GuestIdentity::uniqueKey(),
-                //     ['progress_offset', 'progress_percentage', 'record_id', 'updated_at']
-                // );
+                return response()->json(
+                    $progress->only(['progress_offset', 'progress_percentage', 'completion_count'])
+                );
             }
 
-            return response()->noContent();
+            $progress = GuestIdentity::upsert(
+                'playback_progress',
+                [
+                    ...$identity,
+                    'metadata_id' => $metadata->id,
+                    'progress_offset' => $progressOffset,
+                    'progress_percentage' => $progressPct,
+                    'record_id' => $validated['record_id'] ?? null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                ['progress_offset', 'progress_percentage', 'record_id', 'updated_at']
+            );
+
+            return response()->json(collect((array) $progress)->only(['progress_offset', 'progress_percentage', 'completion_count']));
         } catch (\Throwable $th) {
             Log::error('Playback progress store error', ['metadata_id' => $metadata?->id, 'msg' => $th->getMessage(), 'trace' => $th->getTraceAsString()]);
 

--- a/app/Http/Controllers/Api/V1/PlaybackProgressController.php
+++ b/app/Http/Controllers/Api/V1/PlaybackProgressController.php
@@ -10,12 +10,17 @@ use App\Services\Auth\GuestIdentity;
 use App\Traits\HttpResponses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 class PlaybackProgressController extends Controller {
     use HttpResponses;
 
     public function show(Metadata $metadata) {
+        if (! Auth::check() && ! GuestIdentity::guestToken()) {
+            return $this->forbidden();
+        }
+
         $progress = GuestIdentity::scope(PlaybackProgress::query())
             ->where('metadata_id', $metadata->id)
             ->first(['progress_offset', 'progress_percentage']);

--- a/app/Http/Controllers/Api/V1/PlaybackProgressController.php
+++ b/app/Http/Controllers/Api/V1/PlaybackProgressController.php
@@ -6,17 +6,19 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\PlaybackProgressStoreRequest;
 use App\Models\Metadata;
 use App\Models\PlaybackProgress;
+use App\Services\Auth\GuestIdentity;
 use App\Traits\HttpResponses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 class PlaybackProgressController extends Controller {
     use HttpResponses;
 
     public function show(Metadata $metadata) {
-        $progress = PlaybackProgress::where('user_id', Auth::id())->where('metadata_id', $metadata->id)->first(['progress_offset', 'progress_percentage']);
+        $progress = GuestIdentity::scope(PlaybackProgress::query())
+            ->where('metadata_id', $metadata->id)
+            ->first(['progress_offset', 'progress_percentage']);
 
         return response()->json(['progress_offset' => $progress?->progress_offset ?? 0, 'progress_percentage' => $progress?->progress_percentage ?? 0]);
     }
@@ -26,8 +28,8 @@ class PlaybackProgressController extends Controller {
      */
     public function upsert(PlaybackProgressStoreRequest $request, Metadata $metadata): Response|JsonResponse {
         try {
-            $user_id = Auth::id();
             $validated = $request->validated();
+            $identity = GuestIdentity::identity(); // user_id or guest_token
 
             $duration = $metadata->duration ?? 0;
             $progressOffset = min($validated['progress_offset'], $duration);
@@ -35,7 +37,7 @@ class PlaybackProgressController extends Controller {
             $threshold = config('playback.completion_percentage_threshold', 95);
 
             if ($progressPct >= $threshold) {
-                $progress = PlaybackProgress::firstOrNew(['user_id' => $user_id, 'metadata_id' => $metadata->id]);
+                $progress = PlaybackProgress::firstOrNew([...$identity, 'metadata_id' => $metadata->id]);
 
                 if ($progress->progress_percentage < $threshold) {
                     $progress->last_completed_at = now();
@@ -48,18 +50,32 @@ class PlaybackProgressController extends Controller {
 
                 $progress->save();
             } else {
-                PlaybackProgress::upsert(
+                GuestIdentity::upsert(
+                    'playback_progress',
                     [
-                        'user_id' => $user_id,
+                        ...$identity,
                         'metadata_id' => $metadata->id,
                         'progress_offset' => $progressOffset,
                         'progress_percentage' => $progressPct,
-                        'record_id' => $validated['record_id'] ?? null, // Overwrites existing
+                        'record_id' => $validated['record_id'] ?? null,
+                        'created_at' => now(),
                         'updated_at' => now(),
                     ],
-                    ['user_id', 'metadata_id'],
                     ['progress_offset', 'progress_percentage', 'record_id', 'updated_at']
                 );
+
+                // PlaybackProgress::upsert(
+                //     [
+                //         ...$identity,
+                //         'metadata_id' => $metadata->id,
+                //         'progress_offset' => $progressOffset,
+                //         'progress_percentage' => $progressPct,
+                //         'record_id' => $validated['record_id'] ?? null, // Overwrites existing
+                //         'updated_at' => now(),
+                //     ],
+                //     GuestIdentity::uniqueKey(),
+                //     ['progress_offset', 'progress_percentage', 'record_id', 'updated_at']
+                // );
             }
 
             return response()->noContent();

--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\FolderResource;
 use App\Models\Category;
 use App\Models\Folder;
 use App\Models\Subtitle;
+use App\Services\Auth\GuestIdentity;
 use App\Services\PathResolverService;
 use App\Services\TaskService;
 use App\Traits\HttpResponses;
@@ -102,7 +103,7 @@ class DirectoryController extends Controller {
         $folder->load([
             'series.folderTags.tag',
             'videos.metadata.videoTags.tag',
-            'videos.metadata.playbackProgress' => fn ($q) => $q->where('user_id', Auth::id())->limit(1),
+            'videos.metadata.playbackProgress' => fn ($q) => GuestIdentity::scope($q)->limit(1),
             'videos.metadata.subtitles' => function ($q) {
                 $q->select(Subtitle::getVisibleFields());
             },

--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -101,7 +101,6 @@ class DirectoryController extends Controller {
 
     private function loadFolderData(array $data, FolderResource $folder): array {
         $folder->load([
-            'series.folderTags.tag',
             'videos.metadata.videoTags.tag',
             'videos.metadata.playbackProgress' => fn ($q) => GuestIdentity::scope($q)->limit(1),
             'videos.metadata.subtitles' => function ($q) {

--- a/app/Http/Requests/PlaybackProgressStoreRequest.php
+++ b/app/Http/Requests/PlaybackProgressStoreRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Services\Auth\GuestIdentity;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 
@@ -10,7 +11,7 @@ class PlaybackProgressStoreRequest extends FormRequest {
      * Determine if the user is authorized to make this request.
      */
     public function authorize(): bool {
-        return Auth::check();
+        return Auth::check() || GuestIdentity::guestToken();
     }
 
     /**

--- a/app/Http/Resources/MetadataResource.php
+++ b/app/Http/Resources/MetadataResource.php
@@ -44,9 +44,6 @@ class MetadataResource extends JsonResource {
             'file_modified_at' => $this->first_file_modified_at ?: $this->file_modified_at,
             'first_file_modified_at' => $this->first_file_modified_at,
             'subtitles_scanned_at' => $this->subtitles_scanned_at,
-
-            'progress_offset' => $this->playbackProgress?->progress_offset ?? 0,
-            'progress_percentage' => $this->playbackProgress?->progress_percentage ?? 0,
         ];
     }
 }

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -49,10 +49,10 @@ class VideoResource extends JsonResource {
             'edited_at' => $metadata?->edited_at,
 
             'progress_offset' => $metadata?->playbackProgress?->progress_offset ?? 0,
-            'progress_percentage' =>  $metadata?->playbackProgress?->progress_percentage ?? 0,
-            'completion_count' =>  $metadata?->playbackProgress?->completion_count ?? 0,
+            'progress_percentage' => $metadata?->playbackProgress?->progress_percentage ?? 0,
+            'completion_count' => $metadata?->playbackProgress?->completion_count ?? 0,
 
-            'metadata' => new MetadataResource($metadata)
+            'metadata' => new MetadataResource($metadata),
         ];
     }
 }

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -48,7 +48,11 @@ class VideoResource extends JsonResource {
             'file_modified_at' => $metadata?->first_file_modified_at ?: $metadata?->file_modified_at ?: null, // File Last Modified (Should be date_added)
             'edited_at' => $metadata?->edited_at,
 
-            'metadata' => new MetadataResource($metadata),
+            'progress_offset' => $metadata?->playbackProgress?->progress_offset ?? 0,
+            'progress_percentage' =>  $metadata?->playbackProgress?->progress_percentage ?? 0,
+            'completion_count' =>  $metadata?->playbackProgress?->completion_count ?? 0,
+
+            'metadata' => new MetadataResource($metadata)
         ];
     }
 }

--- a/app/Jobs/Maintenance/PurgeStaleGuestData.php
+++ b/app/Jobs/Maintenance/PurgeStaleGuestData.php
@@ -5,14 +5,11 @@ namespace App\Jobs\Maintenance;
 use App\Enums\TaskStatus;
 use App\Jobs\ManagedSubTask;
 use App\Models\SubTask;
+use App\Services\Auth\GuestMergeService;
 use App\Services\TaskService;
 use Illuminate\Support\Facades\DB;
 
 class PurgeStaleGuestData extends ManagedSubTask {
-    private array $tables = [
-        'playback_progress',
-    ];
-
     /**
      * Create a new job instance.
      *
@@ -35,7 +32,7 @@ class PurgeStaleGuestData extends ManagedSubTask {
         try {
             $expiry = now()->subDays(30);
 
-            foreach ($this->tables as $table) {
+            foreach (GuestMergeService::getGuestTableNames() as $table) {
                 DB::table($table)
                     ->whereNotNull('guest_token')
                     ->where('updated_at', '<', $expiry)

--- a/app/Jobs/Maintenance/PurgeStaleGuestData.php
+++ b/app/Jobs/Maintenance/PurgeStaleGuestData.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs\Maintenance;
+
+use App\Enums\TaskStatus;
+use App\Jobs\ManagedSubTask;
+use App\Models\SubTask;
+use App\Services\TaskService;
+use Illuminate\Support\Facades\DB;
+
+class PurgeStaleGuestData extends ManagedSubTask {
+    private array $tables = [
+        'playback_progress',
+    ];
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        int $taskId,
+    ) {
+        $subTask = SubTask::create(['task_id' => $taskId, 'status' => TaskStatus::PENDING, 'name' => 'Purge Stale Guest Data']);
+
+        $this->taskId = $taskId;
+        $this->subTaskId = $subTask->id;
+    }
+
+    public function handle(TaskService $taskService) {
+        if (! $this->beginSubTask($taskService)) {
+            return;
+        }
+
+        try {
+            $expiry = now()->subDays(30);
+
+            foreach ($this->tables as $table) {
+                DB::table($table)
+                    ->whereNotNull('guest_token')
+                    ->where('updated_at', '<', $expiry)
+                    ->delete();
+            }
+
+            $this->completeSubTask($taskService, 'Purged Expired Guest Data');
+        } catch (\Throwable $th) {
+            $this->failSubTask($taskService, $th);
+            throw $th;
+        }
+    }
+}

--- a/app/Jobs/Maintenance/ScheduledPurgeStaleData.php
+++ b/app/Jobs/Maintenance/ScheduledPurgeStaleData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Jobs\Maintenance;
+
+use App\Services\FileJobService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ScheduledPurgeStaleData implements ShouldQueue {
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(FileJobService $fileJobService): void {
+        $fileJobService->purgeStaleData(['userId' => null, 'namePrefix' => 'Scheduled ']);
+    }
+}

--- a/app/Jobs/ManagedSubTask.php
+++ b/app/Jobs/ManagedSubTask.php
@@ -22,6 +22,10 @@ use Throwable;
 abstract class ManagedSubTask implements ShouldQueue {
     use Batchable, Dispatchable, EnsuresTaskIsStarted, HasUpsert, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 1;
+
+    public int $maxExceptions = 1;
+
     protected int $taskId;
 
     protected ?int $subTaskId = null;

--- a/app/Providers/Api/RouteServiceProvider.php
+++ b/app/Providers/Api/RouteServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Providers\Api;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        $this->configureRateLimiting();
+    }
+
+    protected function configureRateLimiting(): void {
+        // guest token endpoint
+        RateLimiter::for('guest-token', function ($_) {
+            return Limit::perMinute(10)->by(request()->ip());
+        });
+
+        // playback progress endpoint
+        RateLimiter::for('playback-progress', function ($_) {
+            // If expecting a request every 5 seconds (12 per minute per stream)
+            // this allows for 8 simultaneous streams from a single ip
+            return Limit::perMinute(96)->by(request()->ip());
+        });
+
+        RateLimiter::for('lrclib', function (Request $request) {
+            return Limit::perMinute(10)->by($request->user()?->id ?: $request->ip());
+        });
+
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+        });
+    }
+}

--- a/app/Services/Auth/GuestIdentity.php
+++ b/app/Services/Auth/GuestIdentity.php
@@ -34,20 +34,21 @@ class GuestIdentity {
             : ['guest_token', $fk];
     }
 
-    public static function upsert(string $table, array $data, array $updateColumns): void {
+    public static function upsert(string $table, array $data, array $updateColumns): object {
         $conflictTarget = Auth::check()
             ? '(user_id, metadata_id) WHERE user_id IS NOT NULL'
             : '(guest_token, metadata_id) WHERE guest_token IS NOT NULL';
 
         $columns = implode(', ', array_keys($data));
         $placeholders = implode(', ', array_fill(0, count($data), '?'));
-        $updates = implode(', ', array_map(fn ($col) => "{$col} = EXCLUDED.{$col}", $updateColumns));
+        $updates = implode(', ', array_map(fn($col) => "{$col} = EXCLUDED.{$col}", $updateColumns));
 
-        DB::statement("
-        INSERT INTO {$table} ({$columns})
-        VALUES ({$placeholders})
-        ON CONFLICT {$conflictTarget}
-        DO UPDATE SET {$updates}
-    ", array_values($data));
+        return DB::selectOne("
+            INSERT INTO {$table} ({$columns})
+            VALUES ({$placeholders})
+            ON CONFLICT {$conflictTarget}
+            DO UPDATE SET {$updates}
+            RETURNING *
+        ", array_values($data));
     }
 }

--- a/app/Services/Auth/GuestIdentity.php
+++ b/app/Services/Auth/GuestIdentity.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class GuestIdentity {
+    public static function isGuest(): bool {
+        return ! Auth::check();
+    }
+
+    public static function guestToken(): ?string {
+        return request()->header('X-Guest-Token');
+    }
+
+    public static function scope(Builder|Relation $query): Builder|Relation {
+        return Auth::check()
+            ? $query->where('user_id', Auth::id())
+            : $query->where('guest_token', self::guestToken());
+    }
+
+    public static function identity(): array {
+        return Auth::check()
+            ? ['user_id' => Auth::id(), 'guest_token' => null]
+            : ['user_id' => null, 'guest_token' => self::guestToken()];
+    }
+
+    public static function uniqueKey($fk = 'metadata_id'): array {
+        return Auth::check()
+            ? ['user_id', $fk]
+            : ['guest_token', $fk];
+    }
+
+    public static function upsert(string $table, array $data, array $updateColumns): void {
+        $conflictTarget = Auth::check()
+            ? '(user_id, metadata_id) WHERE user_id IS NOT NULL'
+            : '(guest_token, metadata_id) WHERE guest_token IS NOT NULL';
+
+        $columns = implode(', ', array_keys($data));
+        $placeholders = implode(', ', array_fill(0, count($data), '?'));
+        $updates = implode(', ', array_map(fn ($col) => "{$col} = EXCLUDED.{$col}", $updateColumns));
+
+        DB::statement("
+        INSERT INTO {$table} ({$columns})
+        VALUES ({$placeholders})
+        ON CONFLICT {$conflictTarget}
+        DO UPDATE SET {$updates}
+    ", array_values($data));
+    }
+}

--- a/app/Services/Auth/GuestIdentity.php
+++ b/app/Services/Auth/GuestIdentity.php
@@ -41,7 +41,7 @@ class GuestIdentity {
 
         $columns = implode(', ', array_keys($data));
         $placeholders = implode(', ', array_fill(0, count($data), '?'));
-        $updates = implode(', ', array_map(fn($col) => "{$col} = EXCLUDED.{$col}", $updateColumns));
+        $updates = implode(', ', array_map(fn ($col) => "{$col} = EXCLUDED.{$col}", $updateColumns));
 
         return DB::selectOne("
             INSERT INTO {$table} ({$columns})

--- a/app/Services/Auth/GuestMergeService.php
+++ b/app/Services/Auth/GuestMergeService.php
@@ -41,7 +41,7 @@ class GuestMergeService {
     }
 
     public static function getGuestTableNames(): array {
-        return array_keys((new static())->tables);
+        return array_keys((new static)->tables);
     }
 
     private function mergeTable(string $table, array $config, User $user, string $guestToken): void {

--- a/app/Services/Auth/GuestMergeService.php
+++ b/app/Services/Auth/GuestMergeService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Auth;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class GuestMergeService {
+    // Merge config per table
+    private array $tables = [
+        'playback_progress' => [
+            'conflict_key' => '(user_id, metadata_id) WHERE user_id IS NOT NULL',
+            'columns' => [
+                'progress_offset' => 'latest', // take most recent progress offset
+                'progress_percentage' => 'latest',
+                'completion_count' => 'sum', // take sum of all completion counts
+                'last_completed_at' => 'latest',
+                'updated_at' => 'greatest', // take maximum (date) value
+                'record_id' => 'keep_existing',
+            ],
+        ],
+        // TODO: Implement the same system for records
+        // 'records' => [
+        //     'conflict_key' => '(user_id, metadata_id) WHERE user_id IS NOT NULL',
+        //     'columns' => [
+        //         'updated_at' => 'greatest',
+        //     ],
+        // ],
+    ];
+
+    public function merge(User $user, ?string $guestToken): void {
+        if (! $guestToken) {
+            return;
+        }
+
+        DB::transaction(function () use ($user, $guestToken) {
+            foreach ($this->tables as $table => $config) {
+                $this->mergeTable($table, $config, $user, $guestToken);
+            }
+        });
+    }
+
+    private function mergeTable(string $table, array $config, User $user, string $guestToken): void {
+        $updateClause = $this->buildUpdateClause($table, $config['columns']);
+        $columnNames = implode(', ', array_keys($config['columns']));
+
+        // Select columns where guest_token = $guestToken but substituting the table.user_id (which is null) with the current $user->id
+        // Insert into table the values of user_id, metadata_id, ...$columns as user rows instead of guest rows
+        // and on conflict use an update strategy
+
+        // So for example, if you have a guest_playback progress, login, and already have a playback progress for said metadata_id, it will conflict and perform merge strategies per column
+        DB::statement("
+            INSERT INTO {$table} (user_id, metadata_id, {$columnNames})
+            SELECT ?, metadata_id, {$columnNames}
+            FROM {$table}
+            WHERE guest_token = ?
+            ON CONFLICT {$config['conflict_key']}
+            DO UPDATE SET {$updateClause}
+        ", [$user->id, $guestToken]);
+
+        DB::table($table)->where('guest_token', $guestToken)->delete();
+    }
+
+    private function buildUpdateClause(string $table, array $columns): string {
+        $parts = [];
+
+        // Merge Strategies
+        // set column {$column} to {$strategy}
+        // Excluded is the conflict row getting inserted
+        foreach ($columns as $column => $strategy) {
+            $parts[] = match ($strategy ?? 'overwrite') {
+                'sum' => "{$column} = EXCLUDED.{$column} + {$table}.{$column}",
+                'least' => "{$column} = LEAST(EXCLUDED.{$column}, {$table}.{$column})",
+                'greatest' => "{$column} = GREATEST(EXCLUDED.{$column}, {$table}.{$column})",
+                'latest' => "{$column} = CASE WHEN EXCLUDED.updated_at >= {$table}.updated_at THEN EXCLUDED.{$column} ELSE {$table}.{$column} END",
+                'keep_existing' => "{$column} = COALESCE({$table}.{$column}, EXCLUDED.{$column})",
+                'overwrite' => "{$column} = EXCLUDED.{$column}",
+                default => throw new \InvalidArgumentException("Unknown strategy: {$strategy}"),
+            };
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/app/Services/Auth/GuestMergeService.php
+++ b/app/Services/Auth/GuestMergeService.php
@@ -40,6 +40,10 @@ class GuestMergeService {
         });
     }
 
+    public static function getGuestTableNames(): array {
+        return array_keys((new static())->tables);
+    }
+
     private function mergeTable(string $table, array $config, User $user, string $guestToken): void {
         $updateClause = $this->buildUpdateClause($table, $config['columns']);
         $columnNames = implode(', ', array_keys($config['columns']));

--- a/app/Services/Auth/GuestMergeService.php
+++ b/app/Services/Auth/GuestMergeService.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\DB;
 
 class GuestMergeService {
     // Merge config per table
-    private array $tables = [
+    protected array $tables = [
         'playback_progress' => [
             'conflict_key' => '(user_id, metadata_id) WHERE user_id IS NOT NULL',
             'columns' => [

--- a/app/Services/FileJobService.php
+++ b/app/Services/FileJobService.php
@@ -6,6 +6,7 @@ use App\Enums\TaskStatus;
 use App\Jobs\EmbedUidInMetadata;
 use App\Jobs\GeneratePreviewImage;
 use App\Jobs\IndexFiles;
+use App\Jobs\Maintenance\PurgeStaleGuestData;
 use App\Jobs\SyncFiles;
 use App\Jobs\Utility\Paths\CleanFolderPaths;
 use App\Jobs\Utility\Paths\CleanVideoPaths;
@@ -234,6 +235,22 @@ class FileJobService {
                 }
 
                 return $chain;
+            },
+        );
+    }
+
+    public function purgeStaleData(array $data) {
+        $name = 'Purge Stale Data';
+        $description = 'Purges stale data older than 30 days such as guest data.';
+
+        return $this->executeBatchOperation(
+            userId: $data['userId'] ?? null,
+            name: ($data['namePrefix'] ?? '') . $name,
+            description: $description,
+            chain: function ($task) {
+                return [
+                    new PurgeStaleGuestData($task->id),
+                ];
             },
         );
     }

--- a/bootstrap/cache/services.php
+++ b/bootstrap/cache/services.php
@@ -48,6 +48,7 @@
     44 => 'App\\Providers\\AppServiceProvider',
     45 => 'App\\Providers\\HorizonServiceProvider',
     46 => 'App\\Providers\\PathResolverServiceProvider',
+    47 => 'App\\Providers\\Api\\RouteServiceProvider',
   ),
   'eager' => 
   array (
@@ -81,6 +82,7 @@
     27 => 'App\\Providers\\AppServiceProvider',
     28 => 'App\\Providers\\HorizonServiceProvider',
     29 => 'App\\Providers\\PathResolverServiceProvider',
+    30 => 'App\\Providers\\Api\\RouteServiceProvider',
   ),
   'deferred' => 
   array (

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,4 +4,5 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Providers\HorizonServiceProvider::class,
     App\Providers\PathResolverServiceProvider::class,
+    App\Providers\Api\RouteServiceProvider::class,
 ];

--- a/commands.txt
+++ b/commands.txt
@@ -1,5 +1,7 @@
 Auto delete local copies of merged/deleted remote branches
 git branch --merged | %{$_.trim()}  | ?{$_ -notmatch 'dev' -and $_ -notmatch 'main'} | %{git branch -d $_}
+git branch -vv | Where-Object { $_ -match 'gone\]' } | ForEach-Object { $_.Trim().Split()[0] } | ForEach-Object { git branch -D $_ }
+git branch -vv | grep 'gone]' | awk '{print $1}' | xargs git branch -D
 
 Fix sql ID
 select setval('ecommerce."purchases_id_seq"', coalesce((select max(id)+1 from ecommerce.purchases), 1), false)

--- a/database/migrations/2026_04_18_203027_add_guest_id_to_playback_progress.php
+++ b/database/migrations/2026_04_18_203027_add_guest_id_to_playback_progress.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('playback_progress', function (Blueprint $table) {
+            $table->dropUnique(['metadata_id', 'user_id']);
+
+            $table->foreignId('user_id')->nullable()->change();
+            $table->uuid('guest_token')->nullable()->index();
+        });
+
+        DB::statement('CREATE UNIQUE INDEX progress_user_unique ON playback_progress (user_id, metadata_id) WHERE user_id IS NOT NULL');
+        DB::statement('CREATE UNIQUE INDEX progress_guest_unique ON playback_progress (guest_token, metadata_id) WHERE guest_token IS NOT NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('playback_progress', function (Blueprint $table) {
+            $table->dropIndex('progress_guest_unique');
+            $table->dropIndex('progress_user_unique');
+            $table->dropColumn('guest_token');
+            $table->foreignId('user_id')->nullable(false)->change();
+            $table->unique(['metadata_id', 'user_id']);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,9 +4731,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "devOptional": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3387,9 +3387,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -202,7 +202,7 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
             :title="`Progress: ${videoData.progress_percentage}s`"
         >
             <div
-                :class="cn('bg-primary-muted dark:bg-primary-active mt-auto h-full w-full', { 'bg-primary': currentID === videoData.id })"
+                :class="cn('playback-progress-fill bg-foreground-3 mt-auto h-full w-full', { 'bg-primary-muted dark:bg-primary': currentID === videoData.id })"
                 :style="{ width: `${videoData.progress_percentage}%` }"
             ></div>
             <div :class="'h-full w-full flex-1 bg-neutral-300 dark:bg-neutral-700'"></div>
@@ -210,7 +210,17 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
     </RouterLink>
 </template>
 <style lang="css" scoped>
-.data-card-hover .playback-progress-bar {
-    opacity: 1;
+.data-card {
+    &:hover .playback-progress-bar {
+        opacity: 1;
+    }
+
+    &:hover .playback-progress-fill {
+        background-color: var(--color-primary-muted);
+    }
+}
+
+.dark .data-card:hover .playback-progress-fill {
+    background-color: var(--color-primary);
 }
 </style>

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -2,7 +2,7 @@
 import type { ContextMenuItem } from '@/types/types';
 import type { VideoResource } from '@/types/resources';
 
-import { formatFileSize, toFormattedDate } from '@/service/util';
+import { formatFileSize, toFormattedDate, toPlural } from '@/service/util';
 import { getMediaDateDescription } from '@/service/media/mediaFormatter';
 import { computed, toRef } from 'vue';
 import { useContentStore } from '@/stores/ContentStore';
@@ -19,6 +19,7 @@ import useMetaData from '@/composables/useMetaData';
 import MediaTag from '@/components/labels/MediaTag.vue';
 
 import TablerMicrophone2 from '~icons/tabler/microphone-2';
+import ProiconsCheckmark from '~icons/proicons/checkmark';
 import ProiconsComment from '~icons/proicons/comment';
 import CircumShare1 from '~icons/circum/share-1';
 import ProiconsPlay from '~icons/proicons/play';
@@ -37,9 +38,7 @@ const isAudio = computed(() => {
     return videoData.metadata?.media_type === MediaType.AUDIO;
 });
 
-const resumeOffset = computed(() =>
-    videoData.metadata?.progress_offset && videoData.metadata.progress_percentage < 95 && !isAudio.value ? `&t=${videoData.metadata.progress_offset}` : '',
-);
+const resumeOffset = computed(() => (videoData.progress_offset && videoData.progress_percentage < 95 && !isAudio.value ? `&t=${videoData.progress_offset}` : ''));
 
 const contextMenuItems = computed(() => {
     const items: ContextMenuItem[] = [
@@ -127,6 +126,17 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
                         <TablerSubtitles class="size-5 shrink-0 opacity-100 transition-opacity duration-300 *:stroke-[1.4px] hover:opacity-20" title="Has Subtitles" />
                     </template>
                 </HoverCard>
+                <HoverCard
+                    class="xs:block hidden"
+                    v-if="videoData.progress_percentage === 100"
+                    :content-title="`Completed ${videoData.completion_count} time${toPlural(videoData.completion_count)}`"
+                    :hover-card-delay="400"
+                    :hover-card-leave-delay="300"
+                >
+                    <template #trigger>
+                        <ProiconsCheckmark class="size-5 shrink-0 opacity-100 transition-opacity duration-300 *:stroke-[1.4px] hover:opacity-20" title="Completed" />
+                    </template>
+                </HoverCard>
             </span>
 
             <span class="text-foreground-1 flex min-w-fit gap-1 truncate text-sm uppercase">
@@ -183,17 +193,17 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
             ]"
         ></div>
         <div
-            v-if="videoData.metadata?.progress_percentage"
+            v-if="videoData.progress_percentage"
             :class="
                 cn('playback-progress-bar absolute bottom-0 left-0 flex h-1 w-full items-end overflow-clip rounded-b-md opacity-80 dark:opacity-60', {
                     'bottom-0.5 opacity-100 dark:opacity-100': currentID === videoData.id,
                 })
             "
-            :title="`Progress: ${videoData.metadata.progress_percentage}s`"
+            :title="`Progress: ${videoData.progress_percentage}s`"
         >
             <div
                 :class="cn('bg-primary-muted dark:bg-primary-active mt-auto h-full w-full', { 'bg-primary': currentID === videoData.id })"
-                :style="{ width: `${videoData.metadata.progress_percentage}%` }"
+                :style="{ width: `${videoData.progress_percentage}%` }"
             ></div>
             <div :class="'h-full w-full flex-1 bg-neutral-300 dark:bg-neutral-700'"></div>
         </div>

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -129,7 +129,7 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
                 <HoverCard
                     class="xs:block hidden"
                     v-if="videoData.progress_percentage === 100"
-                    :content-title="`Completed ${videoData.completion_count} time${toPlural(videoData.completion_count)}`"
+                    :content-title="`Completed ${videoData.completion_count || 1} time${toPlural(videoData.completion_count || 1)}`"
                     :hover-card-delay="400"
                     :hover-card-leave-delay="300"
                 >

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -202,7 +202,7 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
             :title="`Progress: ${videoData.progress_percentage}s`"
         >
             <div
-                :class="cn('playback-progress-fill bg-foreground-3 mt-auto h-full w-full', { 'bg-primary-muted dark:bg-primary': currentID === videoData.id })"
+                :class="cn('playback-progress-fill bg-foreground-3 mt-auto h-full w-full', { 'bg-primary-muted dark:bg-primary/80': currentID === videoData.id })"
                 :style="{ width: `${videoData.progress_percentage}%` }"
             ></div>
             <div :class="'h-full w-full flex-1 bg-neutral-300 dark:bg-neutral-700'"></div>
@@ -221,6 +221,6 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
 }
 
 .dark .data-card:hover .playback-progress-fill {
-    background-color: var(--color-primary);
+    background-color: var(--color-primary-active);
 }
 </style>

--- a/resources/js/components/cards/data/VideoCard.vue
+++ b/resources/js/components/cards/data/VideoCard.vue
@@ -183,7 +183,7 @@ const dateInformation = computed(() => getMediaDateDescription(videoData));
             ]"
         ></div>
         <div
-            v-if="videoData.metadata?.progress_percentage && videoData.metadata.progress_percentage !== 100 && !isAudio"
+            v-if="videoData.metadata?.progress_percentage"
             :class="
                 cn('playback-progress-bar absolute bottom-0 left-0 flex h-1 w-full items-end overflow-clip rounded-b-md opacity-80 dark:opacity-60', {
                     'bottom-0.5 opacity-100 dark:opacity-100': currentID === videoData.id,

--- a/resources/js/components/dashboard/DashboardLibraries.vue
+++ b/resources/js/components/dashboard/DashboardLibraries.vue
@@ -2,6 +2,7 @@
 import type { CategoryResource, FolderResource } from '@/types/resources';
 import type { BreadCrumbItem } from '@/types/types';
 
+import { folderSortingOptions, librarySortingOptions } from '@/constants/sortingOptions';
 import { computed, ref, watchEffect } from 'vue';
 import { startScanFilesTask } from '@/service/siteAPI';
 import { useDashboardStore } from '@/stores/DashboardStore';
@@ -24,56 +25,6 @@ import ProiconsArrowSync from '~icons/proicons/arrow-sync';
 import ProiconsLibrary from '~icons/proicons/library';
 import ProiconsHome2 from '~icons/proicons/home-2';
 import ProiconsAdd from '~icons/proicons/add';
-
-const sortingOptions = ref([
-    {
-        title: 'Title',
-        value: 'name',
-        disabled: false,
-    },
-    {
-        title: 'Date',
-        value: 'created_at',
-        disabled: false,
-    },
-    {
-        title: 'Folders',
-        value: 'folders_count',
-        disabled: false,
-    },
-    {
-        title: 'Files',
-        value: 'videos_count',
-        disabled: false,
-    },
-    {
-        title: 'Size',
-        value: 'total_size',
-        disabled: false,
-    },
-]);
-
-const folderSortingOptions = ref([
-    {
-        title: 'Title',
-        value: 'name',
-        disabled: false,
-    },
-    {
-        title: 'Date',
-        value: 'created_at',
-        disabled: false,
-    },
-    {
-        title: 'Videos',
-        value: 'file_count',
-        disabled: false,
-    },
-    {
-        title: 'Total Size',
-        value: 'total_size',
-    },
-]);
 
 const { stateLibraries, isLoadingLibraries, stateLibraryId, stateLibraryFolders, isLoadingLibraryFolders } = storeToRefs(useDashboardStore());
 const { pageTitle } = storeToRefs(useAppStore());
@@ -242,7 +193,7 @@ watchEffect(() => {
         :click-action="handleDelete"
         :loading="isLoadingLibraries"
         :sort-action="handleSort"
-        :sorting-options="sortingOptions"
+        :sorting-options="librarySortingOptions"
         v-model="searchQuery"
     />
     <ModalBase :modalData="confirmModal" :action="submitDelete">

--- a/resources/js/components/dashboard/DashboardLibraries.vue
+++ b/resources/js/components/dashboard/DashboardLibraries.vue
@@ -125,9 +125,9 @@ const handleFolderSort = async (column: keyof FolderResource = 'created_at', dir
     return tempList;
 };
 
-const handleStartScan = async () => {
+const handleScanLibrary = async (id?: number) => {
     try {
-        await startScanFilesTask(stateLibraryId.value > 0 ? stateLibraryId.value : undefined);
+        await startScanFilesTask(stateLibraryId.value);
 
         const scanMessage = 'Submitted scan request' + (cachedLibrary.value?.name ? ` for ${cachedLibrary.value.name}!` : '!');
 
@@ -166,7 +166,7 @@ watchEffect(() => {
             <ButtonText title="Add New Library" disabled text="New Library" class="xs:flex-initial hidden flex-1">
                 <template #icon><ProiconsAdd /></template>
             </ButtonText>
-            <ButtonText @click="handleStartScan" title="Index Files" text="Scan For Changes" class="xs:flex-initial flex-1">
+            <ButtonText @click="handleScanLibrary" title="Scan for changes" :text="`Scan ${!!stateLibraryId ? `This Library` : 'All Libraries'}`" class="xs:flex-initial flex-1">
                 <template #icon><ProiconsArrowSync /></template>
             </ButtonText>
         </div>

--- a/resources/js/components/dashboard/DashboardLibraries.vue
+++ b/resources/js/components/dashboard/DashboardLibraries.vue
@@ -120,7 +120,7 @@ const handleSort = async (column: keyof CategoryResource = 'created_at', dir: -1
 };
 
 const handleFolderSort = async (column: keyof FolderResource = 'created_at', dir: -1 | 1 = 1) => {
-    const tempList = [...stateLibraryFolders.value].sort(sortObject<FolderResource>(column, dir, ['created_at']));
+    const tempList = [...stateLibraryFolders.value].sort(sortObject<FolderResource>(column, dir, ['created_at', 'updated_at']));
     stateLibraryFolders.value = tempList;
     return tempList;
 };

--- a/resources/js/components/forms/LoginForm.vue
+++ b/resources/js/components/forms/LoginForm.vue
@@ -39,6 +39,7 @@ const handleLogin = async () => {
         {
             onSuccess: (response: { data: { user: UserResource } }) => {
                 userData.value = response.data.user;
+                useAuthStore().clearGuestToken();
                 router.push(route.query.redirect ? route.query.redirect.toString() : '/');
             },
             onError: () => form.reset('password'),

--- a/resources/js/components/forms/RegisterForm.vue
+++ b/resources/js/components/forms/RegisterForm.vue
@@ -39,6 +39,7 @@ const handleRegister = async () => {
         {
             onSuccess: (response) => {
                 userData.value = response.data.user;
+                useAuthStore().clearGuestToken();
                 router.push({ name: 'root' });
             },
             onError: () => {

--- a/resources/js/components/panels/DropdownMenuItems.ts
+++ b/resources/js/components/panels/DropdownMenuItems.ts
@@ -57,7 +57,10 @@ export function useDropdownMenuItems() {
     });
 
     const dropdownItems: DropdownMenuItem[][] = [
-        [{ ...defaults, name: 'settings', url: '/settings', text: 'Settings', icon: ProiconsSettings }],
+        [
+            { ...defaults, name: 'settings', url: '/settings', text: 'Settings', icon: ProiconsSettings },
+            { ...defaults, name: 'home', url: '/', text: 'Home', icon: LucideTvMinimalPlay },
+        ],
         [
             { ...defaults, name: 'login', url: '/login', text: 'Log in', icon: LucideLogIn },
             { ...defaults, name: 'register', url: '/register', text: 'Sign up', icon: LucideUserPlus },

--- a/resources/js/components/panels/FolderSidebar.vue
+++ b/resources/js/components/panels/FolderSidebar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import type { GenericSortOption, SortDir } from '@/types/types';
 import type { FolderResource } from '@/types/resources';
+import type { SortDir } from '@/types/types';
 
+import { folderSortingOptions } from '@/constants/sortingOptions';
 import { useContentStore } from '@/stores/ContentStore';
 import { formatFileSize } from '@/service/util';
 import { useModalStore } from '@/stores/ModalStore';
@@ -22,29 +23,6 @@ import ProiconsFilterCancel from '~icons/proicons/filter-cancel';
 import ProiconsFilter from '~icons/proicons/filter';
 
 const stickyFilters = true;
-
-const folderSortingOptions: GenericSortOption<FolderResource>[] = [
-    {
-        title: 'Title',
-        value: 'name',
-    },
-    {
-        title: 'Date Created',
-        value: 'created_at',
-    },
-    {
-        title: 'Date Updated',
-        value: 'updated_at',
-    },
-    {
-        title: 'Size',
-        value: 'total_size',
-    },
-    {
-        title: 'File Count',
-        value: 'file_count',
-    },
-];
 
 const modal = useModalStore();
 

--- a/resources/js/components/video/VideoLyrics.vue
+++ b/resources/js/components/video/VideoLyrics.vue
@@ -7,7 +7,7 @@ import { useContentStore } from '@/stores/ContentStore';
 import { useModalStore } from '@/stores/ModalStore';
 import { useLyricStore } from '@/stores/LyricStore';
 import { storeToRefs } from 'pinia';
-import { ButtonIcon } from '@/components/cedar-ui/button';
+import { ButtonText } from '@/components/cedar-ui/button';
 import { onSeek } from '@/service/player/seekBus';
 
 import VideoLyricItem from '@/components/video/VideoLyricItem.vue';
@@ -253,7 +253,7 @@ defineExpose({ scrollToCurrent });
     <div class="pointer-events-auto absolute top-0 right-0 left-0 h-12" style="z-index: 6"></div>
     <div class="pointer-events-auto absolute right-0 bottom-0 left-0 h-16" style="z-index: 6"></div>
     <div class="absolute top-4 right-4 flex gap-1" style="z-index: 7">
-        <ButtonIcon
+        <ButtonText
             variant="ghost"
             :class="[
                 dirtyLyric ? 'opacity-90' : 'bg-transparent opacity-70',
@@ -262,10 +262,8 @@ defineExpose({ scrollToCurrent });
             @click="handleOpenLyricsModal"
             title="Edit Lyrics"
         >
-            <template #text>
-                <p class="h-4">{{ dirtyLyric ? 'preview' : 'edit' }}</p>
-            </template>
-        </ButtonIcon>
+            {{ dirtyLyric ? 'preview' : 'edit' }}
+        </ButtonText>
     </div>
 </template>
 

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -1232,7 +1232,6 @@ watch(
 
         if (value[1] === old[1]) {
             // if time changes but video id does not change
-            console.log(value, old, currentId.value);
             handleLoadUrlTime();
         }
     },

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -1225,6 +1225,20 @@ watch([isThumbnailVisible, viewMode], async () => {
     playerSubtitles.value?.resizeOctopus(); // This doesn't fix the issue. It is a bug with the version of subtitlesOctopus I use
 });
 
+watch(
+    () => [route.query.t, route.query.video],
+    async (value, old) => {
+        if (isLoadingMetadata.value) return;
+
+        if (value[1] === old[1]) {
+            // if time changes but video id does not change
+            console.log(value, old, currentId.value);
+            handleLoadUrlTime();
+        }
+    },
+    { immediate: false },
+);
+
 onMounted(() => {
     if (document.pictureInPictureElement) document.exitPictureInPicture();
     handleLoadSavedVolume();

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -353,17 +353,13 @@ const videoPopoverItems = computed(() => {
             },
         },
         {
-            text: 'Autoplay (p)',
+            text: 'Autoplay',
             title: `Toggle autoplaying the next ${isAudio.value ? 'track' : 'video'}`,
             icon: MagePlaylist,
             selectedIcon: ProiconsCheckmark,
             selected: isPlaylist.value,
             selectedIconStyle: 'text-primary',
-            action: () => {
-                if (isLoading.value) return;
-                isPlaylist.value = !isPlaylist.value;
-                isAutoPlay.value = isPlaylist.value;
-            },
+            action: handleToggleAutoplay,
         },
         {
             text: 'Modern UI',
@@ -994,6 +990,13 @@ const handlePlayPause = (explicitAction?: 'play' | 'pause') => {
     else handlePlayerToggle();
 };
 
+const handleToggleAutoplay = () => {
+    isPlaylist.value = !isPlaylist.value;
+    const mediaType = stateFolder.value.is_majority_audio ? 'track' : 'video';
+    const description = isPlaylist.value ? `Will autoplay the next ${mediaType}.` : `Will not autoplay ${mediaType}s.`;
+    toast(`Autoplay ${isPlaylist.value ? 'Enabled' : 'Disabled'}`, { description });
+};
+
 //#region Keybinds and MediaSession (semi-coupled)
 
 // Debounced actions shared by keybinds and media session action handlers
@@ -1047,10 +1050,7 @@ const handleKeyBinds = (event: KeyboardEvent, override = false) => {
         case 'p':
         case 'P':
             if (!event.shiftKey) {
-                isPlaylist.value = !isPlaylist.value; // Toggle playlist with P
-                const mediaType = stateFolder.value.is_majority_audio ? 'track' : 'video';
-                const description = isPlaylist.value ? `Will autoplay the next ${mediaType}.` : `Will not autoplay ${mediaType}s.`;
-                toast(`Autoplay ${isPlaylist.value ? 'Enabled' : 'Disabled'}`, { description });
+                handleToggleAutoplay(); // Toggle playlist/autoplay with P
                 break;
             }
             handlePrevious();

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -557,6 +557,7 @@ const onPlayerPlay = async (override = false, recordProgress = true) => {
         if (!recordProgress) return;
 
         if (currentId.value === stateVideo.value.id && !override) {
+            startProgressInterval();
             handleProgress();
             return; // stop recording every time video seek
         }
@@ -566,7 +567,7 @@ const onPlayerPlay = async (override = false, recordProgress = true) => {
         isThumbnailDismissed.value = true;
         updateViewCount(stateVideo.value.id);
         handleProgress(true);
-        if (userData.value?.id) startProgressInterval();
+        startProgressInterval();
         getEndTime();
 
         if (isMediaSession.value) navigator.mediaSession.playbackState = 'playing';

--- a/resources/js/components/video/subtitles/OctopusRenderer.ts
+++ b/resources/js/components/video/subtitles/OctopusRenderer.ts
@@ -2,6 +2,7 @@ import type { SubtitlesOctopusOptions } from '@jellyfin/libass-wasm';
 import type { SubtitleResource } from '@/contracts/media';
 import type SubtitlesOctopus from '@jellyfin/libass-wasm';
 
+import { debounce } from 'lodash-es';
 import { toast } from '@aminnausin/cedar-ui';
 import { ref } from 'vue';
 
@@ -71,9 +72,15 @@ export default function useOctopusRenderer() {
         assInstance.value = null;
     };
 
-    const resizeOctopus = () => {
-        if (assInstance.value?.worker) assInstance.value.resize();
+    const resetOctopusCache = async () => {
+        assInstance.value?.resetRenderAheadCache();
     };
+
+    const resizeOctopus = () => {
+        assInstance.value?.resize();
+    };
+
+    const debouncedResetOctopusCache = debounce(resetOctopusCache, 300);
 
     /**
      * Generates a list of language specific fonts based on a predetermined list of files
@@ -100,6 +107,7 @@ export default function useOctopusRenderer() {
     };
 
     return {
+        debouncedResetOctopusCache,
         instantiateOctopus,
         clearOctopus,
         resizeOctopus,

--- a/resources/js/components/video/subtitles/OctopusRenderer.ts
+++ b/resources/js/components/video/subtitles/OctopusRenderer.ts
@@ -77,6 +77,7 @@ export default function useOctopusRenderer() {
     };
 
     const resizeOctopus = () => {
+        assInstance.value?.resetRenderAheadCache();
         assInstance.value?.resize();
     };
 

--- a/resources/js/components/video/subtitles/PlayerSubtitles.vue
+++ b/resources/js/components/video/subtitles/PlayerSubtitles.vue
@@ -3,7 +3,7 @@ import type { SubtitleResource } from '@/types/resources';
 import type { PopoverItem } from '@aminnausin/cedar-ui';
 import type { Ref } from 'vue';
 
-import { computed, inject, nextTick, ref, useTemplateRef } from 'vue';
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
 import { useContentStore } from '@/stores/ContentStore';
 import { storeToRefs } from 'pinia';
 import { round } from 'lodash-es';
@@ -25,7 +25,7 @@ interface PlayerSubtitlesProps {
     getCurrentTime: () => number;
 }
 
-const { instantiateOctopus, clearOctopus, resizeOctopus } = useOctopusRenderer();
+const { instantiateOctopus, clearOctopus, debouncedResetOctopusCache, resizeOctopus } = useOctopusRenderer();
 
 //#region Shared State
 const { stateVideo } = storeToRefs(useContentStore());
@@ -165,6 +165,14 @@ const buildSubtitleUrl = (subtitle?: SubtitleResource): string => {
     const extension = codec === 'ass' ? '.ass' : '.vtt';
     return `/data/subtitles/${metadata_uuid}/${track_id}${languageSlug}${extension}`;
 };
+
+onMounted(() => {
+    window.addEventListener('resize', debouncedResetOctopusCache);
+});
+
+onUnmounted(async () => {
+    window.removeEventListener('resize', debouncedResetOctopusCache);
+});
 
 //#endregion
 defineExpose({

--- a/resources/js/composables/player/usePlaybackProgress.ts
+++ b/resources/js/composables/player/usePlaybackProgress.ts
@@ -4,10 +4,8 @@ import { playbackProgressTrackingInterval } from '@/service/player/playerConstan
 import { getProgress, upsertProgress } from '@/service/api/playbackProgress';
 import { watch, onUnmounted } from 'vue';
 import { useContentStore } from '@/stores/ContentStore';
-import { useAuth } from '@/composables/auth/useAuth';
 
 export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => number) {
-    const { isAuthenticated } = useAuth();
     const contentStore = useContentStore();
 
     let interval: ReturnType<typeof setInterval> | null = null;

--- a/resources/js/composables/player/usePlaybackProgress.ts
+++ b/resources/js/composables/player/usePlaybackProgress.ts
@@ -7,8 +7,8 @@ import { useContentStore } from '@/stores/ContentStore';
 import { useAuth } from '@/composables/auth/useAuth';
 
 export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => number) {
-    const contentStore = useContentStore();
     const { isAuthenticated } = useAuth();
+    const contentStore = useContentStore();
 
     let interval: ReturnType<typeof setInterval> | null = null;
 
@@ -23,14 +23,12 @@ export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => 
 
         if (pct < 5) return;
 
-        await upsertProgress(id, {
+        const { data } = await upsertProgress(id, {
             progress_offset: offset,
         });
 
-        contentStore.updatePlaybackProgress(id, {
-            progress_offset: offset,
-            progress_percentage: pct,
-        });
+        // this should use server-side resulting data from the upsert
+        contentStore.updatePlaybackProgress(id, data);
     };
 
     const startInterval = () => {

--- a/resources/js/composables/player/usePlaybackProgress.ts
+++ b/resources/js/composables/player/usePlaybackProgress.ts
@@ -32,11 +32,6 @@ export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => 
     };
 
     const startInterval = () => {
-        if (!isAuthenticated) {
-            stopInterval();
-            return;
-        }
-
         if (interval) return;
 
         interval = setInterval(save, playbackProgressTrackingInterval);

--- a/resources/js/composables/player/usePlaybackProgress.ts
+++ b/resources/js/composables/player/usePlaybackProgress.ts
@@ -4,9 +4,11 @@ import { playbackProgressTrackingInterval } from '@/service/player/playerConstan
 import { getProgress, upsertProgress } from '@/service/api/playbackProgress';
 import { watch, onUnmounted } from 'vue';
 import { useContentStore } from '@/stores/ContentStore';
+import { useAuth } from '@/composables/auth/useAuth';
 
 export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => number) {
     const contentStore = useContentStore();
+    const { isAuthenticated } = useAuth();
 
     let interval: ReturnType<typeof setInterval> | null = null;
 
@@ -32,7 +34,13 @@ export function usePlaybackProgress(mediaId: Ref<number>, getCurrentTime: () => 
     };
 
     const startInterval = () => {
-        stopInterval();
+        if (!isAuthenticated) {
+            stopInterval();
+            return;
+        }
+
+        if (interval) return;
+
         interval = setInterval(save, playbackProgressTrackingInterval);
     };
 

--- a/resources/js/constants/sortingOptions.ts
+++ b/resources/js/constants/sortingOptions.ts
@@ -1,0 +1,48 @@
+import type { GenericSortOption } from '@/types/types';
+import type { CategoryResource, FolderResource } from '@/contracts/media';
+
+export const librarySortingOptions: GenericSortOption<CategoryResource>[] = [
+    {
+        title: 'Title',
+        value: 'name',
+    },
+    {
+        title: 'Date',
+        value: 'created_at',
+    },
+    {
+        title: 'Folders',
+        value: 'folders_count',
+    },
+    {
+        title: 'Files',
+        value: 'videos_count',
+    },
+    {
+        title: 'Size',
+        value: 'total_size',
+    },
+];
+
+export const folderSortingOptions: GenericSortOption<FolderResource>[] = [
+    {
+        title: 'Title',
+        value: 'name',
+    },
+    {
+        title: 'Date Created',
+        value: 'created_at',
+    },
+    {
+        title: 'Date Updated',
+        value: 'updated_at',
+    },
+    {
+        title: 'Size',
+        value: 'total_size',
+    },
+    {
+        title: 'File Count',
+        value: 'file_count',
+    },
+];

--- a/resources/js/constants/sortingOptions.ts
+++ b/resources/js/constants/sortingOptions.ts
@@ -1,5 +1,5 @@
+import type { CategoryResource, FolderResource, VideoResource } from '@/contracts/media';
 import type { GenericSortOption } from '@/types/types';
-import type { CategoryResource, FolderResource } from '@/contracts/media';
 
 export const librarySortingOptions: GenericSortOption<CategoryResource>[] = [
     {
@@ -44,5 +44,68 @@ export const folderSortingOptions: GenericSortOption<FolderResource>[] = [
     {
         title: 'File Count',
         value: 'file_count',
+    },
+];
+
+export const mediaSortingOptions = (folder: FolderResource): GenericSortOption<VideoResource>[] => [
+    {
+        title: 'Title',
+        value: 'title',
+        disabled: false,
+    },
+    {
+        title: 'Date Uploaded',
+        value: 'file_modified_at',
+        disabled: false,
+    },
+    {
+        title: 'Date Released',
+        value: 'released_at',
+        disabled: false,
+    },
+    {
+        title: 'Views',
+        value: 'view_count',
+        disabled: false,
+    },
+    {
+        title: 'Artist',
+        value: 'artist',
+        disabled: !folder.is_majority_audio,
+        hidden: !folder.is_majority_audio,
+    },
+    {
+        title: 'Album',
+        value: 'album',
+        disabled: !folder.is_majority_audio,
+        hidden: !folder.is_majority_audio,
+    },
+    {
+        title: folder.is_majority_audio ? 'Track Number' : `Episode`,
+        value: 'episode',
+        disabled: false,
+    },
+    {
+        title: folder.is_majority_audio ? 'Disc Number' : 'Season',
+        value: 'season',
+        disabled: false,
+    },
+    {
+        title: 'Duration',
+        value: 'duration',
+        disabled: false,
+    },
+    {
+        title: 'File Size',
+        value: 'file_size',
+        disabled: false,
+    },
+    {
+        title: 'Watch Progress',
+        value: 'progress_percentage',
+    },
+    {
+        title: 'Times Completed',
+        value: 'completion_count',
     },
 ];

--- a/resources/js/contracts/media.ts
+++ b/resources/js/contracts/media.ts
@@ -110,9 +110,6 @@ export interface MetadataResource {
     file_modified_at?: string;
     first_file_modified_at?: string;
     subtitles_scanned_at?: string;
-
-    progress_offset?: number;
-    progress_percentage: number;
 }
 
 export interface VideoResource {
@@ -138,6 +135,9 @@ export interface VideoResource {
     edited_at?: string;
     metadata?: MetadataResource;
     subtitles: SubtitleResource[];
+    progress_offset: number;
+    progress_percentage: number;
+    completion_count: number;
 }
 
 export interface SubtitleResource {

--- a/resources/js/router/index.ts
+++ b/resources/js/router/index.ts
@@ -1,6 +1,7 @@
 import type { NavigationGuardNext, RouteLocationNormalizedGeneric, RouteLocationNormalizedLoadedGeneric } from 'vue-router';
 
 import { createRouter, createWebHistory } from 'vue-router';
+import { useContentStore } from '@/stores/ContentStore';
 import { useAuthStore } from '@/stores/AuthStore';
 import { toTitleCase } from '@/service/util';
 import { logout } from '@/service/authAPI';
@@ -8,7 +9,6 @@ import { toast } from '@aminnausin/cedar-ui';
 
 import ErrorView from '@/views/ErrorView.vue';
 import nProgress from 'nprogress';
-import { useContentStore } from '@/stores/ContentStore';
 
 interface RouteMeta {
     title?: string;

--- a/resources/js/router/index.ts
+++ b/resources/js/router/index.ts
@@ -8,6 +8,7 @@ import { toast } from '@aminnausin/cedar-ui';
 
 import ErrorView from '@/views/ErrorView.vue';
 import nProgress from 'nprogress';
+import { useContentStore } from '@/stores/ContentStore';
 
 interface RouteMeta {
     title?: string;
@@ -58,13 +59,15 @@ export const router = createRouter({
             name: 'logout',
             beforeEnter: async (to, from, next) => {
                 const authStore = useAuthStore();
+                const contentStore = useContentStore();
                 const meta = from.meta as { title?: string; protected?: boolean };
 
                 let nextPath = from.fullPath;
                 let nextTitle = meta?.title ?? toTitleCase(`${from.name?.toString()}`);
                 try {
-                    if (authStore.userData) {
+                    if (authStore.isAuthenticated) {
                         await logout(); // call API only if session is thought to be valid
+                        contentStore.clearUserContentState();
                     }
                 } catch (error: any) {
                     if (error?.response?.status !== 419 && error?.response?.status !== 401) {
@@ -72,7 +75,10 @@ export const router = createRouter({
                         console.error(error);
                     }
                 }
+
                 authStore.clearAuthState();
+                authStore.clearGuestToken();
+                await authStore.initGuestToken();
 
                 if (meta?.protected || from.name === 'logout') {
                     nextPath = '/';

--- a/resources/js/service/api.ts
+++ b/resources/js/service/api.ts
@@ -30,15 +30,20 @@ function flushQueue(success: boolean) {
     queue = [];
 }
 
+const completeNProgress = (force = false) => {
+    if (progressTimeout) {
+        clearTimeout(progressTimeout);
+        nProgress.done(force);
+    }
+};
+
 const handleResponse = (response: any) => {
-    clearTimeout(progressTimeout);
-    nProgress.done(true);
+    completeNProgress();
     return response;
 };
 
 const handleError = async (error: AxiosError<{ message?: string }>) => {
-    clearTimeout(progressTimeout);
-    nProgress.done(true);
+    completeNProgress();
 
     const auth = useAuthStore();
     const status = error.response?.status ?? 0;
@@ -128,10 +133,10 @@ API.interceptors.request.use((config) => {
 
     const hideProgressBar = config?.headers?.['X-Skip-Progress'] === 'true';
 
-    clearTimeout(progressTimeout);
-    nProgress.done(true);
-
-    if (!hideProgressBar) progressTimeout = setTimeout(() => nProgress.start(), 100);
+    if (!hideProgressBar) {
+        completeNProgress();
+        progressTimeout = setTimeout(() => nProgress.start(), 100);
+    }
     if (guestToken) config.headers['X-Guest-Token'] = guestToken;
 
     return config;

--- a/resources/js/service/api.ts
+++ b/resources/js/service/api.ts
@@ -124,10 +124,15 @@ export async function getMediaUrl(path: string): Promise<string> {
 }
 
 API.interceptors.request.use((config) => {
+    const { guestToken } = useAuthStore();
+
+    const hideProgressBar = config?.headers?.['X-Skip-Progress'] === 'true';
+
     clearTimeout(progressTimeout);
     nProgress.done(true);
 
-    progressTimeout = setTimeout(() => nProgress.start(), 100);
+    if (!hideProgressBar) progressTimeout = setTimeout(() => nProgress.start(), 100);
+    if (guestToken) config.headers['X-Guest-Token'] = guestToken;
 
     return config;
 });

--- a/resources/js/service/api/playbackProgress.ts
+++ b/resources/js/service/api/playbackProgress.ts
@@ -1,9 +1,11 @@
 import type { PlaybackProgressStoreRequest } from '@/types/requests';
+import type { PlaybackProgressResponse } from '@/types/types';
+
 import { API } from '../api';
 
 export const getProgress = (mediaId: number) => API.get(`/metadata/${mediaId}/progress`);
 export const upsertProgress = (mediaId: number, payload: PlaybackProgressStoreRequest) =>
-    API.put(`/metadata/${mediaId}/progress`, payload, {
+    API.put<PlaybackProgressResponse>(`/metadata/${mediaId}/progress`, payload, {
         headers: {
             'X-Skip-Progress': true,
         },

--- a/resources/js/service/api/playbackProgress.ts
+++ b/resources/js/service/api/playbackProgress.ts
@@ -2,4 +2,9 @@ import type { PlaybackProgressStoreRequest } from '@/types/requests';
 import { API } from '../api';
 
 export const getProgress = (mediaId: number) => API.get(`/metadata/${mediaId}/progress`);
-export const upsertProgress = (mediaId: number, payload: PlaybackProgressStoreRequest) => API.put(`/metadata/${mediaId}/progress`, payload);
+export const upsertProgress = (mediaId: number, payload: PlaybackProgressStoreRequest) =>
+    API.put(`/metadata/${mediaId}/progress`, payload, {
+        headers: {
+            'X-Skip-Progress': true,
+        },
+    });

--- a/resources/js/service/sort/baseSort.test.ts
+++ b/resources/js/service/sort/baseSort.test.ts
@@ -5,19 +5,29 @@ import { sortObjectNew } from '@/service/sort/baseSort';
 import { expect, test } from 'vitest';
 
 test('CompareStrategies.episode sorts by season and episode', () => {
-    const videos: VideoResource[] = [
-        { id: 1, name: '1', path: '/1', view_count: 0, video_tags: [], season: 2, episode: 2, created_at: '', subtitles: [] },
-        { id: 3, name: '3', path: '/3', view_count: 0, video_tags: [], season: 2, episode: 1, created_at: '', subtitles: [] },
-        { id: 2, name: '2', path: '/2', view_count: 0, video_tags: [], season: 1, episode: 1, created_at: '', subtitles: [] },
-        { id: 4, name: '4', path: '/4', view_count: 0, video_tags: [], season: 1, episode: 2, created_at: '', subtitles: [] },
+    const baseMedia = {
+        view_count: 0,
+        progress_offset: 0,
+        progress_percentage: 0,
+        completion_count: 0,
+        video_tags: [],
+        subtitles: [],
+        created_at: '',
+    };
+
+    const media: VideoResource[] = [
+        { id: 1, name: '1', path: '/1', season: 2, episode: 2, ...baseMedia },
+        { id: 3, name: '3', path: '/3', season: 2, episode: 1, ...baseMedia },
+        { id: 2, name: '2', path: '/2', season: 1, episode: 1, ...baseMedia },
+        { id: 4, name: '4', path: '/4', season: 1, episode: 2, ...baseMedia },
     ];
 
-    videos.sort(sortObjectNew([{ compareFn: CompareStrategies.episode }]));
+    media.sort(sortObjectNew([{ compareFn: CompareStrategies.episode }]));
 
-    expect(videos).toEqual([
-        { id: 2, name: '2', path: '/2', view_count: 0, video_tags: [], season: 1, episode: 1, created_at: '', subtitles: [] },
-        { id: 4, name: '4', path: '/4', view_count: 0, video_tags: [], season: 1, episode: 2, created_at: '', subtitles: [] },
-        { id: 3, name: '3', path: '/3', view_count: 0, video_tags: [], season: 2, episode: 1, created_at: '', subtitles: [] },
-        { id: 1, name: '1', path: '/1', view_count: 0, video_tags: [], season: 2, episode: 2, created_at: '', subtitles: [] },
+    expect(media).toEqual([
+        { id: 2, name: '2', path: '/2', season: 1, episode: 1, ...baseMedia },
+        { id: 4, name: '4', path: '/4', season: 1, episode: 2, ...baseMedia },
+        { id: 3, name: '3', path: '/3', season: 2, episode: 1, ...baseMedia },
+        { id: 1, name: '1', path: '/1', season: 2, episode: 2, ...baseMedia },
     ]);
 });

--- a/resources/js/stores/AuthStore.ts
+++ b/resources/js/stores/AuthStore.ts
@@ -26,7 +26,7 @@ export const useAuthStore = defineStore('Auth', () => {
 
     const clearGuestToken = () => {
         guestToken.value = null;
-        localStorage.removeItem('guest_token');
+        // localStorage.removeItem('guest_token');
     };
 
     const fetchUser = async (force: boolean = false): Promise<boolean> => {

--- a/resources/js/stores/AuthStore.ts
+++ b/resources/js/stores/AuthStore.ts
@@ -26,7 +26,7 @@ export const useAuthStore = defineStore('Auth', () => {
 
     const clearGuestToken = () => {
         guestToken.value = null;
-        // localStorage.removeItem('guest_token');
+        localStorage.removeItem('guest_token');
     };
 
     const fetchUser = async (force: boolean = false): Promise<boolean> => {

--- a/resources/js/stores/AuthStore.ts
+++ b/resources/js/stores/AuthStore.ts
@@ -4,13 +4,30 @@ import { computed, ref } from 'vue';
 import { authenticate } from '@/service/authAPI';
 import { defineStore } from 'pinia';
 import { toast } from '@aminnausin/cedar-ui';
+import { API } from '@/service/api';
 
 // This code is not good
 export const useAuthStore = defineStore('Auth', () => {
     const userData = ref<null | UserResource>(null);
     const isLoadingUserData = ref<boolean>(false);
 
+    const guestToken = ref<string | null>(localStorage.getItem('guest_token'));
+
     let userFetchPromise: Promise<boolean> | null = null;
+
+    const initGuestToken = async () => {
+        if (isAuthenticated.value || guestToken.value) return;
+
+        const { data } = await API.post('/guest-token');
+
+        guestToken.value = data.token;
+        localStorage.setItem('guest_token', data.token);
+    };
+
+    const clearGuestToken = () => {
+        guestToken.value = null;
+        localStorage.removeItem('guest_token');
+    };
 
     const fetchUser = async (force: boolean = false): Promise<boolean> => {
         /*
@@ -33,10 +50,12 @@ export const useAuthStore = defineStore('Auth', () => {
 
                 if (data.isAuthenticated) {
                     userData.value = data.user;
+                    clearGuestToken();
                     return true;
                 }
 
                 clearAuthState(false);
+                await initGuestToken();
                 return false;
             } catch (error) {
                 // Only when network or server error
@@ -73,7 +92,10 @@ export const useAuthStore = defineStore('Auth', () => {
         isAuthenticated,
         isAdmin,
         isLoadingUserData,
+        guestToken,
         fetchUser,
         clearAuthState,
+        initGuestToken,
+        clearGuestToken,
     };
 });

--- a/resources/js/stores/ContentStore.ts
+++ b/resources/js/stores/ContentStore.ts
@@ -26,7 +26,19 @@ const emptyLibrary: CategoryResource = {
     downloads_require_auth: false,
 };
 const emptyFolder: FolderResource = { id: 0, name: '', title: '', path: '', file_count: 0, total_size: 0, is_majority_audio: false, category_id: 0, videos: [], last_scan: -1 };
-const emptyMedia: VideoResource = { id: 0, name: '', path: '', view_count: 0, video_tags: [], created_at: '', subtitles: [] };
+const emptyMedia: VideoResource = {
+    id: 0,
+    name: '',
+    path: '',
+
+    view_count: 0,
+    progress_offset: 0,
+    progress_percentage: 0,
+    completion_count: 0,
+    video_tags: [],
+    subtitles: [],
+    created_at: '',
+};
 
 const DEFAULT_SORT = { column: 'name', dir: 1 };
 
@@ -323,19 +335,21 @@ export const useContentStore = defineStore('Content', () => {
         if (data.progress_offset < 0 || data.progress_percentage < 0 || data.progress_percentage > 100) return;
 
         const apply = (video: VideoResource) => {
-            if (video.metadata?.id !== id) return;
+            const duration = video.duration ?? 0;
 
-            const duration = video.metadata?.duration ?? 0;
+            video.progress_offset = Math.min(data.progress_offset, duration);
+            video.progress_percentage = data.progress_percentage;
 
-            video.metadata.progress_offset = Math.min(data.progress_offset, duration);
-            video.metadata.progress_percentage = data.progress_percentage;
+            if (data.progress_percentage === 100) video.completion_count++;
         };
 
         if (stateVideo.value.metadata?.id === id) {
             apply(stateVideo.value);
+            return;
         }
 
         for (const video of stateFolder.value.videos ?? []) {
+            if (video.metadata?.id !== id) return;
             apply(video);
         }
     }

--- a/resources/js/stores/ContentStore.ts
+++ b/resources/js/stores/ContentStore.ts
@@ -359,8 +359,10 @@ export const useContentStore = defineStore('Content', () => {
         }
 
         for (const video of stateFolder.value.videos ?? []) {
-            if (video.metadata?.id !== id) return;
-            apply(video);
+            if (video.metadata?.id === id) {
+                apply(video);
+                return;
+            }
         }
     }
 

--- a/resources/js/stores/ContentStore.ts
+++ b/resources/js/stores/ContentStore.ts
@@ -330,17 +330,19 @@ export const useContentStore = defineStore('Content', () => {
         stateVideo.value = emptyMedia;
     }
 
-    function updatePlaybackProgress(id: number, data: { progress_offset: number; progress_percentage: number }) {
+    function updatePlaybackProgress(id: number, data: { progress_offset: number; progress_percentage: number; completion_count: number }) {
         if (Number.isNaN(id)) return;
-        if (data.progress_offset < 0 || data.progress_percentage < 0 || data.progress_percentage > 100) return;
 
         const apply = (video: VideoResource) => {
             const duration = video.duration ?? 0;
 
+            if (data.completion_count == video.completion_count + 1 && data.progress_percentage === 100) {
+                // TODO: trigger activity toast? This is a good point to save series watch activity. toast.add('Video Completed', { description: 'Save to Anilist?' });
+            }
+
             video.progress_offset = Math.min(data.progress_offset, duration);
             video.progress_percentage = data.progress_percentage;
-
-            if (data.progress_percentage === 100) video.completion_count++;
+            video.completion_count = data.completion_count;
         };
 
         if (stateVideo.value.metadata?.id === id) {

--- a/resources/js/stores/ContentStore.ts
+++ b/resources/js/stores/ContentStore.ts
@@ -330,6 +330,14 @@ export const useContentStore = defineStore('Content', () => {
         stateVideo.value = emptyMedia;
     }
 
+    function clearUserContentState() {
+        stateFolder.value.videos.forEach((video) => {
+            video.progress_offset = 0;
+            video.progress_percentage = 0;
+            video.completion_count = 0;
+        });
+    }
+
     function updatePlaybackProgress(id: number, data: { progress_offset: number; progress_percentage: number; completion_count: number }) {
         if (Number.isNaN(id)) return;
 
@@ -385,5 +393,6 @@ export const useContentStore = defineStore('Content', () => {
         updatePlaybackProgress,
         playlistFind,
         playlistSort,
+        clearUserContentState,
     };
 });

--- a/resources/js/types/subtitles-octopus.d.ts
+++ b/resources/js/types/subtitles-octopus.d.ts
@@ -2,44 +2,53 @@ declare module '@jellyfin/libass-wasm' {
     export interface SubtitlesOctopusOptions {
         video: HTMLVideoElement;
 
-        subUrl?: string;
-        subContent?: string;
+        // Performance
+        dropAllAnimations?: boolean;
+        libassMemoryLimit?: number;
+        libassGlyphLimit?: number;
 
-        workerUrl: string;
-        wasmUrl?: string;
+        // Rendering
+        targetFps?: number;
+        prescaleFactor?: number;
+        prescaleHeightLimit?: number; // Default 1080
+        maxRenderHeight?: number; // Default 0 (no limit)
+        resizeVariation?: number;
+        renderAhead?: number; // Render ahead by x MiB
 
-        fonts?: string[];
-        availableFonts?: Record<string, string>;
+        // Fonts
+        fonts: string[];
+        availableFonts?: { [fontNameLowercase: string]: string };
         fallbackFont?: string;
 
-        worker?: Worker;
+        // Events
+        onReady?: () => void;
+        onError?: (error: any) => void;
 
-        timeOffset?: number;
-        playbackRate?: number;
+        // Resources
+        subUrl: string;
+        workerUrl: string;
 
-        width?: number;
-        height?: number;
-
+        // Other
         debug?: boolean;
-        targetFps?: number;
-        renderAhead?: number;
-
-        onError?: () => void;
+        timeOffset?: number;
     }
 
     export default class SubtitlesOctopus {
         constructor(options: SubtitlesOctopusOptions);
 
         dispose(): void;
+        freeTrack(): void;
 
         setTrackByUrl(url: string): void;
         setTrack(content: string): void;
-        freeTrack(): void;
 
         setCurrentTime(time: number): void;
         setIsPaused(paused: boolean): void;
         setRate(rate: number): void;
+
         resize(width?: number, height?: number): void;
+        resizeWithTimeout(): void;
+        resetRenderAheadCache(isResizing?: boolean): void;
 
         worker?: Worker;
     }

--- a/resources/js/types/types.ts
+++ b/resources/js/types/types.ts
@@ -270,3 +270,9 @@ export interface WaitTimesResponse {
     verify_folders?: number;
     embed_uid?: number;
 }
+
+export interface PlaybackProgressResponse {
+    progress_offset: number;
+    progress_percentage: number;
+    completion_count: number;
+}

--- a/resources/js/views/VideoView.vue
+++ b/resources/js/views/VideoView.vue
@@ -127,6 +127,14 @@ const sortingOptions = computed(() => [
         value: 'file_size',
         disabled: false,
     },
+    {
+        title: 'Watch Progress',
+        value: 'progress_percentage',
+    },
+    {
+        title: 'Times Completed',
+        value: 'completion_count',
+    },
 ]) satisfies ComputedRef<GenericSortOption<VideoResource>[]>; // Idk what the point of using satisfies is
 
 const handleSort = (column: keyof VideoResource = 'file_modified_at', dir: SortDir = 1) => {

--- a/resources/js/views/VideoView.vue
+++ b/resources/js/views/VideoView.vue
@@ -24,10 +24,12 @@ import VideoSidebar from '@/components/panels/VideoSidebar.vue';
 import LayoutBase from '@/layouts/LayoutBase.vue';
 import ShareModal from '@/components/modals/ShareModal.vue';
 import VideoCard from '@/components/cards/data/VideoCard.vue';
+import { useAuth } from '@/composables/auth/useAuth';
 
-const { selectedSideBar, pageTitle } = storeToRefs(useAppStore());
-const { getFolder, getCategory, playlistFind, playlistSort, updateVideoData } = useContentStore();
+const { getFolder, getCategory, playlistFind, playlistSort, clearUserContentState } = useContentStore();
 const { searchQuery, stateFilteredPlaylist, stateDirectory, stateVideo, stateFolder } = storeToRefs(useContentStore());
+const { selectedSideBar, pageTitle } = storeToRefs(useAppStore());
+const { isAuthenticated } = useAuth();
 
 const ambientPlayer = useTemplateRef('ambientPlayer');
 
@@ -150,6 +152,14 @@ watch(
         await reload();
     },
     { immediate: false },
+);
+watch(
+    () => isAuthenticated.value,
+    (value, old) => {
+        if (!value && old) {
+            clearUserContentState();
+        }
+    },
 );
 watch(() => selectedSideBar.value, cycleSideBar, { immediate: false });
 watch(() => stateFolder.value, setFolderAsPageTitle);

--- a/resources/js/views/VideoView.vue
+++ b/resources/js/views/VideoView.vue
@@ -24,12 +24,10 @@ import VideoSidebar from '@/components/panels/VideoSidebar.vue';
 import LayoutBase from '@/layouts/LayoutBase.vue';
 import ShareModal from '@/components/modals/ShareModal.vue';
 import VideoCard from '@/components/cards/data/VideoCard.vue';
-import { useAuth } from '@/composables/auth/useAuth';
 
 const { getFolder, getCategory, playlistFind, playlistSort, clearUserContentState } = useContentStore();
 const { searchQuery, stateFilteredPlaylist, stateDirectory, stateVideo, stateFolder } = storeToRefs(useContentStore());
 const { selectedSideBar, pageTitle } = storeToRefs(useAppStore());
-const { isAuthenticated } = useAuth();
 
 const ambientPlayer = useTemplateRef('ambientPlayer');
 
@@ -152,14 +150,6 @@ watch(
         await reload();
     },
     { immediate: false },
-);
-watch(
-    () => isAuthenticated.value,
-    (value, old) => {
-        if (!value && old) {
-            clearUserContentState();
-        }
-    },
 );
 watch(() => selectedSideBar.value, cycleSideBar, { immediate: false });
 watch(() => stateFolder.value, setFolderAsPageTitle);

--- a/resources/js/views/VideoView.vue
+++ b/resources/js/views/VideoView.vue
@@ -5,6 +5,7 @@ import type { ComputedRef } from 'vue';
 import type { SortDir } from '@/service/sort/types';
 
 import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { mediaSortingOptions } from '@/constants/sortingOptions';
 import { useContentStore } from '@/stores/ContentStore';
 import { useModalStore } from '@/stores/ModalStore';
 import { toParamNumber } from '@/util/route';
@@ -74,68 +75,7 @@ async function reload() {
 
 //#region TABLE
 
-const sortingOptions = computed(() => [
-    {
-        title: 'Title',
-        value: 'title',
-        disabled: false,
-    },
-    {
-        title: 'Date Uploaded',
-        value: 'file_modified_at',
-        disabled: false,
-    },
-    {
-        title: 'Date Released',
-        value: 'released_at',
-        disabled: false,
-    },
-    {
-        title: 'Views',
-        value: 'view_count',
-        disabled: false,
-    },
-    {
-        title: 'Artist',
-        value: 'artist',
-        disabled: !stateFolder.value.is_majority_audio,
-        hidden: !stateFolder.value.is_majority_audio,
-    },
-    {
-        title: 'Album',
-        value: 'album',
-        disabled: !stateFolder.value.is_majority_audio,
-        hidden: !stateFolder.value.is_majority_audio,
-    },
-    {
-        title: stateFolder.value.is_majority_audio ? 'Track Number' : `Episode`,
-        value: 'episode',
-        disabled: false,
-    },
-    {
-        title: stateFolder.value.is_majority_audio ? 'Disc Number' : 'Season',
-        value: 'season',
-        disabled: false,
-    },
-    {
-        title: 'Duration',
-        value: 'duration',
-        disabled: false,
-    },
-    {
-        title: 'File Size',
-        value: 'file_size',
-        disabled: false,
-    },
-    {
-        title: 'Watch Progress',
-        value: 'progress_percentage',
-    },
-    {
-        title: 'Times Completed',
-        value: 'completion_count',
-    },
-]) satisfies ComputedRef<GenericSortOption<VideoResource>[]>; // Idk what the point of using satisfies is
+const sortingOptions = computed(() => mediaSortingOptions(stateFolder.value)) satisfies ComputedRef<GenericSortOption<VideoResource>[]>; // Idk what the point of using satisfies is
 
 const handleSort = (column: keyof VideoResource = 'file_modified_at', dir: SortDir = 1) => {
     playlistSort({ column, dir });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\AnalyticsController;
+use App\Http\Controllers\Api\V1\Auth\GuestTokenController;
 use App\Http\Controllers\Api\V1\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\CategoryController;
@@ -127,6 +128,7 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register'])->middleware('throttle:6,1')->name('register');
 Route::post('/recovery', [PasswordResetLinkController::class, 'store'])->name('password.recovery');
 Route::post('/reset-password/{token}', [PasswordController::class, 'store'])->name('password.reset');
+Route::post('/guest-token', [GuestTokenController::class, 'issue']);
 
 // App Info
 Route::get('/manifest', fn () => response()->json(AppManifest::info()));

--- a/routes/api.php
+++ b/routes/api.php
@@ -72,9 +72,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::patch('/lyrics', [MetadataController::class, 'updateLyrics']);
         // Subtitles
         Route::delete('/subtitles', [SubtitleController::class, 'reset']); // clear cache
-        // Progress
-        Route::get('/progress', [PlaybackProgressController::class, 'show']);
-        Route::put('/progress', [PlaybackProgressController::class, 'upsert']);
     });
 
     Route::prefix('/categories/{category}')->group(function () {
@@ -152,6 +149,13 @@ Route::resource('/playback', PlaybackController::class)->only(['show', 'store'])
 Route::prefix('/media/{video}')->group(function () {
     // Downloads
     Route::get('/download', [MediaController::class, 'download']);
+});
+
+// Public Metadata
+Route::prefix('/metadata/{metadata}')->group(function () {
+    // Progress
+    Route::get('/progress', [PlaybackProgressController::class, 'show']);
+    Route::put('/progress', [PlaybackProgressController::class, 'upsert']);
 });
 
 // Lyrics Service

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,7 +125,7 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register'])->middleware('throttle:6,1')->name('register');
 Route::post('/recovery', [PasswordResetLinkController::class, 'store'])->name('password.recovery');
 Route::post('/reset-password/{token}', [PasswordController::class, 'store'])->name('password.reset');
-Route::post('/guest-token', [GuestTokenController::class, 'issue']);
+Route::post('/guest-token', [GuestTokenController::class, 'issue'])->middleware('throttle:guest-token');
 
 // App Info
 Route::get('/manifest', fn () => response()->json(AppManifest::info()));
@@ -155,12 +155,13 @@ Route::prefix('/media/{video}')->group(function () {
 Route::prefix('/metadata/{metadata}')->group(function () {
     // Progress
     Route::get('/progress', [PlaybackProgressController::class, 'show']);
-    Route::put('/progress', [PlaybackProgressController::class, 'upsert']);
+    Route::put('/progress', [PlaybackProgressController::class, 'upsert'])->middleware('throttle:playback-progress');
+    // Lyrics Service
+    Route::prefix('/lyrics')->middleware('throttle:lrclib')->group(function () {
+        Route::get('/import', [ExternalMetadataController::class, 'importLyrics']);
+        Route::get('/search', [ExternalMetadataController::class, 'searchLyrics']);
+    });
 });
-
-// Lyrics Service
-Route::get('/metadata/{id}/lyrics/import', [ExternalMetadataController::class, 'importLyrics']);
-Route::get('/metadata/{id}/lyrics/search', [ExternalMetadataController::class, 'searchLyrics']);
 
 // Content
 Route::get('/{dir}', [DirectoryController::class, 'showDirectoryAPI']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Jobs\Maintenance\ScheduledPurgeStaleData;
 use App\Jobs\ScheduledIndexFiles;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::job(new ScheduledIndexFiles)->twiceDaily()->withoutOverlapping()->environments(['staging', 'production']);
+Schedule::job(new ScheduledPurgeStaleData)->daily()->withoutOverlapping();
+
 Schedule::command('auth:clear-resets')->everyFifteenMinutes();
 Schedule::command('sanctum:prune-expired --hours=2')->daily();
 

--- a/tests/Feature/Auth/GuestMergeServiceTest.php
+++ b/tests/Feature/Auth/GuestMergeServiceTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Unit\Services\Auth;
+
+use App\Models\Metadata;
+use App\Models\PlaybackProgress;
+use App\Models\Record;
+use App\Models\User;
+use App\Services\Auth\GuestMergeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuestMergeServiceTest extends TestCase {
+    use RefreshDatabase;
+
+    private GuestMergeService $service;
+
+    private User $user;
+
+    private Metadata $metadata;
+
+    private string $guestToken;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->service = new GuestMergeService;
+        $this->user = User::factory()->create();
+        $this->metadata = Metadata::factory()->create(['duration' => 100]);
+        $this->guestToken = fake()->uuid();
+    }
+
+    private function createGuestProgress(array $overrides = []): PlaybackProgress {
+        return PlaybackProgress::factory()->create([
+            'user_id' => null,
+            'guest_token' => $this->guestToken,
+            'metadata_id' => $this->metadata->id,
+            ...$overrides,
+        ]);
+    }
+
+    private function createUserProgress(array $overrides = []): PlaybackProgress {
+        return PlaybackProgress::factory()->create([
+            'user_id' => $this->user->id,
+            'guest_token' => null,
+            'metadata_id' => $this->metadata->id,
+            ...$overrides,
+        ]);
+    }
+
+    // -------------------------
+    // Basic merge behaviour
+    // -------------------------
+
+    public function test_merge_does_nothing_with_null_token(): void {
+        $this->createGuestProgress(['progress_offset' => 50]);
+
+        $this->service->merge($this->user, null);
+
+        $this->assertDatabaseHas('playback_progress', ['guest_token' => $this->guestToken]);
+    }
+
+    public function test_merge_transfers_guest_row_to_user_when_no_conflict(): void {
+        $this->createGuestProgress(['progress_offset' => 50, 'progress_percentage' => 50]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'metadata_id' => $this->metadata->id,
+            'progress_offset' => 50,
+            'progress_percentage' => 50,
+            'guest_token' => null,
+        ]);
+    }
+
+    public function test_merge_deletes_guest_rows_after_transfer(): void {
+        $this->createGuestProgress();
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseMissing('playback_progress', ['guest_token' => $this->guestToken]);
+    }
+
+    public function test_merge_handles_multiple_guest_rows_across_different_media(): void {
+        $metadata2 = Metadata::factory()->create(['duration' => 200]);
+
+        PlaybackProgress::factory()->create([
+            'user_id' => null,
+            'guest_token' => $this->guestToken,
+            'metadata_id' => $this->metadata->id,
+            'progress_offset' => 40,
+        ]);
+
+        PlaybackProgress::factory()->create([
+            'user_id' => null,
+            'guest_token' => $this->guestToken,
+            'metadata_id' => $metadata2->id,
+            'progress_offset' => 80,
+        ]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseCount('playback_progress', 2);
+        $this->assertDatabaseMissing('playback_progress', ['guest_token' => $this->guestToken]);
+    }
+
+    // -------------------------
+    // Conflict strategies
+    // -------------------------
+
+    public function test_latest_strategy_takes_guest_value_when_guest_row_is_newer(): void {
+        $this->createUserProgress([
+            'progress_offset' => 80,
+            'updated_at' => now()->subHour(),
+        ]);
+
+        $this->createGuestProgress([
+            'progress_offset' => 40,
+            'updated_at' => now(),
+        ]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'progress_offset' => 40, // guest value is more recent
+        ]);
+    }
+
+    public function test_latest_strategy_keeps_user_value_when_user_row_is_newer(): void {
+        $this->createUserProgress([
+            'progress_offset' => 80,
+            'updated_at' => now(),
+        ]);
+
+        $this->createGuestProgress([
+            'progress_offset' => 40,
+            'updated_at' => now()->subHour(),
+        ]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'progress_offset' => 80, // user value is more recent
+        ]);
+    }
+
+    public function test_sum_strategy_adds_completion_counts(): void {
+        $this->createUserProgress(['completion_count' => 3]);
+        $this->createGuestProgress(['completion_count' => 2]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'completion_count' => 5,
+        ]);
+    }
+
+    public function test_greatest_strategy_takes_most_recent_updated_at(): void {
+        $older = now()->subDay();
+        $newer = now();
+
+        $this->createUserProgress(['updated_at' => $older]);
+        $this->createGuestProgress(['updated_at' => $newer]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $progress = PlaybackProgress::where('user_id', $this->user->id)
+            ->where('metadata_id', $this->metadata->id)
+            ->first();
+
+        $this->assertTrue($progress->updated_at->gte($newer->subSecond()));
+    }
+
+    public function test_keep_existing_strategy_preserves_user_record_id(): void {
+        $record = Record::factory()->create([
+            'user_id' => $this->user->id,
+            'metadata_id' => $this->metadata->id,
+        ]);
+
+        // The guest system isn't implemented for records so this is a fake record with a userId instead of a guestToken
+        $record2 = Record::factory()->create([
+            'user_id' => $this->user->id,
+            'metadata_id' => $this->metadata->id,
+        ]);
+        $this->createUserProgress(['record_id' => $record->id]);
+        $this->createGuestProgress(['record_id' => $record2->id]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'record_id' => $record->id,
+        ]);
+    }
+
+    public function test_keep_existing_strategy_takes_guest_record_id_when_user_has_none(): void {
+        $record = Record::factory()->create([
+            'user_id' => $this->user->id,
+            'metadata_id' => $this->metadata->id,
+        ]);
+
+        $this->createUserProgress(['record_id' => null]);
+        $this->createGuestProgress(['record_id' => $record->id]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'record_id' => $record->id,
+        ]);
+    }
+
+    // -------------------------
+    // Edge cases
+    // -------------------------
+
+    public function test_merge_with_no_guest_rows_does_nothing(): void {
+        $this->createUserProgress(['progress_offset' => 50]);
+
+        $this->service->merge($this->user, $this->guestToken);
+
+        $this->assertDatabaseHas('playback_progress', [
+            'user_id' => $this->user->id,
+            'progress_offset' => 50,
+        ]);
+    }
+
+    public function test_merge_is_wrapped_in_transaction(): void {
+        // Force second table to fail by using invalid table in config
+        // This test verifies the transaction rolls back on failure
+        $this->createGuestProgress(['progress_offset' => 50]);
+
+        $brokenService = new class extends GuestMergeService {
+            protected array $tables = [
+                'playback_progress' => [
+                    'conflict_key' => '(user_id, metadata_id) WHERE user_id IS NOT NULL',
+                    'columns' => ['progress_offset' => 'latest', 'updated_at' => 'greatest'],
+                ],
+                'nonexistent_table' => [
+                    'conflict_key' => '(user_id, metadata_id) WHERE user_id IS NOT NULL',
+                    'columns' => ['updated_at' => 'greatest'],
+                ],
+            ];
+        };
+
+        try {
+            $brokenService->merge($this->user, $this->guestToken);
+        } catch (\Throwable) {
+        }
+
+        // guest row should still exist — transaction rolled back
+        $this->assertDatabaseHas('playback_progress', ['guest_token' => $this->guestToken]);
+    }
+}

--- a/tests/Feature/Auth/GuestMergeServiceTest.php
+++ b/tests/Feature/Auth/GuestMergeServiceTest.php
@@ -229,8 +229,8 @@ class GuestMergeServiceTest extends TestCase {
     }
 
     public function test_merge_is_wrapped_in_transaction(): void {
-        // Force second table to fail by using invalid table in config
-        // This test verifies the transaction rolls back on failure
+        // Force second table to fail by using fake table name in config
+        // This should rollback all merge transactions
         $this->createGuestProgress(['progress_offset' => 50]);
 
         $brokenService = new class extends GuestMergeService {
@@ -249,9 +249,8 @@ class GuestMergeServiceTest extends TestCase {
         try {
             $brokenService->merge($this->user, $this->guestToken);
         } catch (\Throwable) {
+            // transaction rolled back
+            $this->assertDatabaseHas('playback_progress', ['guest_token' => $this->guestToken]);
         }
-
-        // guest row should still exist — transaction rolled back
-        $this->assertDatabaseHas('playback_progress', ['guest_token' => $this->guestToken]);
     }
 }

--- a/tests/Feature/Playback/PlaybackProgressControllerTest.php
+++ b/tests/Feature/Playback/PlaybackProgressControllerTest.php
@@ -74,7 +74,7 @@ class PlaybackProgressControllerTest extends TestCase {
 
     public function test_show_requires_authentication(): void {
         $this->getJson("/api/metadata/{$this->metadata->id}/progress")
-            ->assertUnauthorized();
+            ->assertForbidden();
     }
 
     // -------------------------
@@ -190,7 +190,7 @@ class PlaybackProgressControllerTest extends TestCase {
     public function test_upsert_requires_authentication(): void {
         $this->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 40,
-        ])->assertUnauthorized();
+        ])->assertForbidden();
     }
 
     public function test_upsert_requires_progress_offset(): void {

--- a/tests/Feature/Playback/PlaybackProgressControllerTest.php
+++ b/tests/Feature/Playback/PlaybackProgressControllerTest.php
@@ -84,7 +84,7 @@ class PlaybackProgressControllerTest extends TestCase {
     public function test_upsert_creates_new_progress_record(): void {
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 40,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->assertDatabaseHas('playback_progress', [
             'user_id' => $this->user->id,
@@ -104,7 +104,7 @@ class PlaybackProgressControllerTest extends TestCase {
 
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 60,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->assertDatabaseHas('playback_progress', [
             'user_id' => $this->user->id,
@@ -119,7 +119,7 @@ class PlaybackProgressControllerTest extends TestCase {
     public function test_upsert_clamps_offset_to_duration(): void {
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 999,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->assertDatabaseHas('playback_progress', [
             'user_id' => $this->user->id,
@@ -131,7 +131,7 @@ class PlaybackProgressControllerTest extends TestCase {
     public function test_upsert_marks_completion_at_threshold(): void {
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 96,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $progress = PlaybackProgress::where('user_id', $this->user->id)
             ->where('metadata_id', $this->metadata->id)
@@ -155,7 +155,7 @@ class PlaybackProgressControllerTest extends TestCase {
 
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 98,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->assertDatabaseHas('playback_progress', [
             'user_id' => $this->user->id,
@@ -176,11 +176,11 @@ class PlaybackProgressControllerTest extends TestCase {
         // progress gets set to below the threshold and then completes again
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 10,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->actingAsUser()->putJson("/api/metadata/{$this->metadata->id}/progress", [
             'progress_offset' => 97,
-        ])->assertNoContent();
+        ])->assertOk();
 
         $this->assertDatabaseHas('playback_progress', [
             'completion_count' => 2,


### PR DESCRIPTION
### Fixes

- #289 
- #292 
- Dashboard Library scan button does not convey that it scans the current library only

### Changes

- Playback progress shows when completed for videos and audio
- Added a link to the default library in the user dropdown when not logged in

### Additions

- Completion count on `videoCard`
- Save playback progress as a guest user without logging in
  - When logging in or registering, any guest data will be automatically merged with existing or new user data
- Added sort by progress and completion count to playlist table

### Demo

- Completion Count
  <img width="704" height="145" alt="image" src="https://github.com/user-attachments/assets/ba78c030-077a-4b9f-98c0-9d857352a514" />

- Playback Progress
  <img width="718" height="217" alt="image" src="https://github.com/user-attachments/assets/8e45b099-8f2f-41c2-9818-0b22831d7eca" />

