### PR TITLE
fix/uncaught-orientation-lock

### DIFF
--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -780,7 +780,7 @@ const cycleViewMode = async (mode: PlayerViewMode) => {
             if (viewMode.value === 'fullscreen') break;
             if (isPictureInPicture.value) await togglePictureInPicture();
             if (document.fullscreenElement === null) await container.value.requestFullscreen();
-            if (!isAudio.value) await (screen.orientation as ScreenOrientation).lock?.('landscape');
+            if (!isAudio.value && 'lock' in screen.orientation) screen.orientation.lock('landscape').catch(() => {});
             viewMode.value = 'fullscreen';
             document.documentElement.classList.add('fullscreen');
             break;


### PR DESCRIPTION
### Fixes

- Screen orientation lock breaks player on unsupported devices with browser level support (desktop)
  - Breaks player actions upon entering fullscreen
  - Keybinds, menus and and fullscreen buttons fail
- Tested on:
  - Edge (Desktop)
  - Firefox (Desktop)
  - Firefox (Android)
  - Edge (Android)