### PR TITLE
Fix/preview migration

### DIFF
--- a/app/Enums/ImageSource.php
+++ b/app/Enums/ImageSource.php
@@ -2,14 +2,14 @@
 
 namespace App\Enums;
 
-enum ImageSource: int {
-    case GENERATED = 0;
-    case UPLOADED = 1;
-    case API = 2;
-    case URL = 3; // external url, not downloaded, makes no sense
-    case DOWNLOADED = 4;
-    case EMBEDDED = 5;
-    case LEGACY = 6;
+enum ImageSource: string {
+    case GENERATED = 'generated';
+    case UPLOADED = 'uploaded';
+    case API = 'api';
+    case URL = 'url'; // external url, not downloaded, makes no sense
+    case DOWNLOADED = 'downloaded';
+    case EMBEDDED = 'embedded';
+    case LEGACY = 'legacy';
 
     public function label(): string {
         return strtolower($this->name);

--- a/app/Enums/ImageType.php
+++ b/app/Enums/ImageType.php
@@ -6,5 +6,5 @@ enum ImageType: string {
     case POSTER = 'poster';
     case BANNER = 'banner';
     case AVATAR = 'avatar';
-    case PREVIEW = 'preview';
+    case OGP = 'preview';
 }

--- a/app/Enums/ImageType.php
+++ b/app/Enums/ImageType.php
@@ -2,12 +2,9 @@
 
 namespace App\Enums;
 
-enum ImageType: int {
-    case POSTER = 0;
-    case BANNER = 1;
-    case AVATAR = 2;
-
-    public function label(): string {
-        return strtolower($this->name);
-    }
+enum ImageType: string {
+    case POSTER = 'poster';
+    case BANNER = 'banner';
+    case AVATAR = 'avatar';
+    case PREVIEW = 'preview';
 }

--- a/app/Http/Resources/ImageResource.php
+++ b/app/Http/Resources/ImageResource.php
@@ -14,7 +14,9 @@ class ImageResource extends JsonResource {
     public function toArray(Request $request): array {
         return [
             'id' => $this->id,
-            'path' => "/storage/{$this->path}",
+            'path' => asset("/storage/{$this->path}"),
+            'type' => $this->image_type->value,
+            'source' => $this->image_source->value,
             'blur_hash' => $this->blur_hash,
         ];
     }

--- a/app/Http/Resources/MetadataResource.php
+++ b/app/Http/Resources/MetadataResource.php
@@ -26,6 +26,7 @@ class MetadataResource extends JsonResource {
 
             'poster_url' => $this->poster_url,
             'poster_image' => $this->primaryPoster ? new ImageResource($this->primaryPoster) : null,
+            'images' => ImageResource::collection($this->images),
 
             'duration' => $this->duration,
             'mime_type' => $this->mime_type,

--- a/app/Jobs/GeneratePreviewImage.php
+++ b/app/Jobs/GeneratePreviewImage.php
@@ -7,9 +7,10 @@ use App\Models\SubTask;
 use App\Services\GenerateImageException;
 use App\Services\PreviewGeneratorService;
 use App\Services\TaskService;
+use Illuminate\Database\Eloquent\Model;
 
 class GeneratePreviewImage extends ManagedSubTask {
-    protected $itemTitle;
+    protected string $itemTitle;
 
     public $timeout = 3600;
 
@@ -20,10 +21,10 @@ class GeneratePreviewImage extends ManagedSubTask {
      */
     public function __construct(
         public array $data,
-        public string $path,
+        public Model $owner,
         int $taskId,
     ) {
-        $this->itemTitle = $data['title'] ?? $path;
+        $this->itemTitle = $data['title'] ?? $owner->name ?? 'Unknown';
 
         $subTask = SubTask::create(['task_id' => $taskId, 'status' => TaskStatus::PENDING, 'name' => "Regenerate Preview Image for '{$this->itemTitle}'"]);
 
@@ -37,11 +38,11 @@ class GeneratePreviewImage extends ManagedSubTask {
         }
 
         try {
-            $result = $previewGenerator->generateImage($this->data, $this->path, true);
-            if (! $result) {
+            $image = $previewGenerator->generateAndPersist($this->owner, $this->data);
+            if (! $image) {
                 throw new GenerateImageException('Preview image generation failed. View logs for error.');
             }
-            $this->completeSubTask($taskService, 'Generated preview image.');
+            $this->completeSubTask($taskService, "Generated preview image at {$image->path}.");
         } catch (\Throwable $th) {
             $this->failSubTask($taskService, $th);
             throw $th;

--- a/app/Jobs/Metadata/GenerateStoryboard.php
+++ b/app/Jobs/Metadata/GenerateStoryboard.php
@@ -25,7 +25,7 @@ class GenerateStoryboard extends ManagedSubTask {
 
     protected string $uuid;
 
-    public int $timeout = 600;
+    public int $timeout = 2400;
 
     public int $tries = 1;
 

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -17,8 +17,8 @@ class Image extends Model {
      *
      * user_id          -> int8 (fk) (nullable) (onDelete=setNull)
      *
-     * image_type       -> int2 (enum) (composite index with imageable_type, imageable_id, replaced_at)
-     * image_source     -> int2 (enum)
+     * image_type       -> string (enum) (composite index with imageable_type, imageable_id, replaced_at)
+     * image_source     -> string (enum)
      * image_variant    -> string (enum) (nullable)
      *
      * width            -> int4 (nullable)
@@ -68,6 +68,6 @@ class Image extends Model {
         $variant = $this->image_variant ? "_{$this->image_variant->value}" : '';
         $ext = $this->format ?? 'webp';
 
-        return $this->image_type->label() . "{$variant}.{$ext}";
+        return $this->image_type->value . "{$variant}.{$ext}";
     }
 }

--- a/app/Services/FileJobService.php
+++ b/app/Services/FileJobService.php
@@ -231,10 +231,10 @@ class FileJobService {
                 $chain = [];
 
                 foreach ($rows as $row) {
-                    if (! isset($row['data']) || ! isset($row['path'])) {
+                    if (! isset($row['data']) || ! isset($row['owner'])) {
                         continue;
                     }
-                    $chain[] = new GeneratePreviewImage($row['data'], $row['path'], $task->id);
+                    $chain[] = new GeneratePreviewImage($row['data'], $row['owner'], $task->id);
                 }
 
                 return $chain;

--- a/app/Services/Images/ImageService.php
+++ b/app/Services/Images/ImageService.php
@@ -261,13 +261,40 @@ class ImageService {
         return [$relativePath, $absolutePath];
     }
 
-    public function persistImage(Model $owner, ImageData $data): Image {
+    public function persistImage(Model $owner, ImageData $data, bool $overwrite = false): Image {
         if (! file_exists($data->absolutePath) || filesize($data->absolutePath) === 0) {
             throw new FileNotFoundException("Image file does not exist: {$data->absolutePath}");
         }
 
         $uuid = $owner->uuid ?? throw new \InvalidArgumentException('Owner must have a UUID');
         [$width, $height] = getimagesize($data->absolutePath);
+
+        if ($overwrite) {
+            return Image::updateOrCreate(
+                [
+                    'imageable_id' => $uuid,
+                    'imageable_type' => $owner::class,
+                    'image_type' => $data->type,
+                    'replaced_at' => null,
+                ],
+                [
+                    'user_id' => $data->userId,
+
+                    'image_source' => $data->source,
+                    'image_variant' => $data->variant,
+
+                    'width' => $width,
+                    'height' => $height,
+                    'size' => filesize($data->absolutePath),
+
+                    'path' => $data->relativePath,
+                    'format' => $data->format,
+                    'source_url' => $data->sourceUrl,
+
+                    'blur_hash' => $this->generateBlurHash($data->absolutePath),
+                ]
+            );
+        }
 
         Image::where([
             'imageable_id' => $uuid,

--- a/app/Services/Images/ImageService.php
+++ b/app/Services/Images/ImageService.php
@@ -30,7 +30,7 @@ class ImageService {
         $offset = min(30, (int) ($metadata->duration * 0.1)); // 10% in or 30s min
         $fmt = 'webp';
 
-        [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($metadata, ImageType::POSTER, $fmt);
+        [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($metadata, ImageType::POSTER, $fmt, null, true);
 
         $process = new Process([
             'ffmpeg',
@@ -92,7 +92,7 @@ class ImageService {
     public function extractPoster(string $filePath, Metadata $metadata, ?int $userId = null): ?Image {
         $fmt = 'webp'; // Audio supports png only ?
 
-        [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($metadata, ImageType::POSTER, $fmt);
+        [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($metadata, ImageType::POSTER, $fmt, null, true);
 
         $process = new Process([
             'ffmpeg',
@@ -153,7 +153,7 @@ class ImageService {
         try {
             $fmt = 'webp';
 
-            [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($owner, $imageType, $fmt);
+            [$relativeOutputPath, $absoluteOutputPath] = $this->resolvePath($owner, $imageType, $fmt, null, true);
 
             $response = Http::get($url);
 
@@ -238,7 +238,7 @@ class ImageService {
      * Path: metadata/{imageable}/{shard}/{uuid}/{type->label}.{format}
      * Disk: public
      */
-    private function resolvePath(Model $owner, ImageType $type, string $format, ?ImageVariant $variant = null): array {
+    public function resolvePath(Model $owner, ImageType $type, string $format, ?ImageVariant $variant = null, bool $useHash = false): array {
         $uuid = $owner->uuid ?? $owner->getKey();
 
         // TODO: This really needs to go outside of this file. "metadata/metadata" is defined all over the place and needs to be central and consistent
@@ -252,8 +252,8 @@ class ImageService {
         $relativeDir = "metadata/{$prefix}/" . substr($uuid, 0, 2) . "/{$uuid}";
         $disk->makeDirectory($relativeDir);
 
-        $hash = substr(str_replace('-', '', (string) Str::uuid()), 0, 8);
-        $filename = $type->label() . ($variant ? "_{$variant->value}" : '') . "_{$hash}.{$format}";
+        $hash = $useHash ? '_' . substr(str_replace('-', '', (string) Str::uuid()), 0, 8) : '';
+        $filename = $type->value . ($variant ? "_{$variant->value}" : '') . "{$hash}.{$format}";
 
         $relativePath = "{$relativeDir}/{$filename}";
         $absolutePath = str_replace('\\', '/', $disk->path($relativePath));
@@ -261,12 +261,13 @@ class ImageService {
         return [$relativePath, $absolutePath];
     }
 
-    private function persistImage(Model $owner, ImageData $data): Image {
+    public function persistImage(Model $owner, ImageData $data): Image {
         if (! file_exists($data->absolutePath) || filesize($data->absolutePath) === 0) {
             throw new FileNotFoundException("Image file does not exist: {$data->absolutePath}");
         }
 
         $uuid = $owner->uuid ?? throw new \InvalidArgumentException('Owner must have a UUID');
+        [$width, $height] = getimagesize($data->absolutePath);
 
         Image::where([
             'imageable_id' => $uuid,
@@ -274,8 +275,6 @@ class ImageService {
             'image_type' => $data->type,
             'replaced_at' => null,
         ])->update(['replaced_at' => now()]);
-
-        [$width, $height] = getimagesize($data->absolutePath);
 
         return Image::create([
             'imageable_id' => $uuid,

--- a/app/Services/Images/Storyboard/StoryboardOptions.php
+++ b/app/Services/Images/Storyboard/StoryboardOptions.php
@@ -44,6 +44,7 @@ class StoryboardOptions {
         $intervalSeconds = max(1, config('media.storyboard.default_interval_seconds', 10)); // min configured value is every second
 
         $fps = match (true) {
+            $metadata->duration < 5 => 10, // every 100ms
             $metadata->duration < 10 => 2, // every 500ms
             $metadata->duration < 30 => 1, // every second
             $metadata->duration < 120 => 0.5, // every other second

--- a/app/Services/PathResolverService.php
+++ b/app/Services/PathResolverService.php
@@ -38,10 +38,9 @@ class PathResolverService {
             ->select(...$select)->find((int) $identifier);
     }
 
-    public function resolveFolder(string $identifier, Category $category, ?Collection $folders = null, bool $onlyPublic = false): ?Folder {
+    public function resolveFolder(string $identifier, Category $category, ?Collection $folders = null): ?Folder {
         if (! $folders) {
-            $query = Folder::with('series')->where('category_id', $category->id);
-            $folders = $this->addPrivacyFilter($query, $onlyPublic)->get();
+            $folders = Folder::with('series')->where('category_id', $category->id)->get();
         }
 
         return $this->firstSuccessful([

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -95,8 +95,6 @@ class PreviewGeneratorService {
             $this->queueRegeneration($owner, $data);
         }
 
-        $this->queueRegeneration($owner, $data);
-
         if (! $override && $existingRow) {
             return ImageService::getImageUrl($existingRow->path);
         }
@@ -170,7 +168,7 @@ class PreviewGeneratorService {
         return match (true) {
             $owner instanceof Series => $owner->folder_id ? self::LEGACY_PREVIEW_PREFIX . "folders/{$owner->folder_id}.png" : null,
             $owner instanceof Metadata => ($owner->video?->folder?->path && $owner->video_id) ? self::LEGACY_PREVIEW_PREFIX . "{$owner->video?->folder?->path}/{$owner->video_id}.png" : null,
-            default => tap(null, fn () => Log::warning('PreviewGeneratorService: resolveLegacyPath called with unsupported owner', ['owner' => $owner::class, 'id' => $owner->id])),
+            default => tap(null, fn() => Log::warning('PreviewGeneratorService: resolveLegacyPath called with unsupported owner', ['owner' => $owner::class, 'id' => $owner->id])),
         };
     }
 
@@ -196,7 +194,7 @@ class PreviewGeneratorService {
             'upload_date' => $this->formatDate($series->created_at),
             'content_string' => $contentString,
             'rating' => $series->rating,
-            'tags' => $series->folder_tags ? array_map(fn ($tag) => $tag->name, $series->folder_tags) : null,
+            'tags' => $series->folder_tags ? array_map(fn($tag) => $tag->name, $series->folder_tags) : null,
             'url' => $request->fullUrl(),
             'last_updated' => strtotime($series->updated_at ?? ''),
         ];
@@ -224,7 +222,7 @@ class PreviewGeneratorService {
             'release_date' => $releaseDate,
             'upload_date' => $this->formatDate($metadata->file_modified_at),
             'mime_type' => $metadata->mime_type,
-            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
+            'tags' => $metadata->video_tags ? array_map(fn($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
             'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
             'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),
@@ -493,6 +491,8 @@ class PreviewGeneratorService {
     // endregion
 }
 
-class ChromiumException extends Exception {}
+class ChromiumException extends Exception {
+}
 
-class GenerateImageException extends Exception {}
+class GenerateImageException extends Exception {
+}

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -75,7 +75,7 @@ class PreviewGeneratorService {
      * If the owner has been edited since the last image was generated, a new one is queued to generate.
      */
     protected function handleGenerateImage(Model $owner, array $data, ?int $dataLastUpdated = 0): ?string {
-        $override = config('services.preview_generator.override'); // Forces generation in local environment
+        $override = false; // config('services.preview_generator.override'); // Forces generation in local environment
 
         $existingRow = Image::where([
             'imageable_id' => $owner->uuid,
@@ -197,7 +197,10 @@ class PreviewGeneratorService {
             'rating' => $series->rating,
             'tags' => $series->folderTags->pluck('tag.name')->all(),
             'url' => $request->fullUrl(),
-            'last_updated' => strtotime($series->updated_at ?? ''),
+            'last_updated' => collect([
+                $series->updated_at,
+                $series->edited_at,
+            ])->max()?->timestamp ?? 0,
         ];
     }
 
@@ -207,15 +210,15 @@ class PreviewGeneratorService {
 
         // Poster for music does not auto migrate?
         $metadataPoster = $metadata->primaryPoster?->path ? "storage/{$metadata->primaryPoster->path}" : $metadata->poster_url; // Backwards Compatible
-        $seriesPoster = $series->primaryPoster?->path ? "storage/{$series->primaryPoster->path}" : $series->thumbnail_url;
+        $seriesPoster = $series?->primaryPoster?->path ? "storage/{$series->primaryPoster->path}" : $series?->thumbnail_url;
         $poster = $seriesPoster ?: $this->defaultPoster;
         $banner = $metadataPoster ?: $seriesPoster ?: $this->defaultPoster;
 
         $releaseDate = MediaFormatter::formatDate($metadata->released_at ?: $metadata->file_modified_at);
 
         return [
-            'title' => ucfirst($series->title) . " · {$metadata->title}",
-            'description' => $metadata->description ?: $series->description ?: 'No description is available.',
+            'title' => ucfirst($series?->title ?? 'Unknown') . " · {$metadata->title}",
+            'description' => $metadata->description ?: $series?->description ?: 'No description is available.',
             'thumbnail_url' => $this->encodeImageURL($poster),
             'banner_url' => $this->encodeImageURL($banner),
             'is_audio' => $isAudio,
@@ -226,7 +229,12 @@ class PreviewGeneratorService {
             'tags' => $metadata->videoTags ? $metadata->videoTags->pluck('tag.name')->all() : [MediaFormatter::formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
             'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
-            'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),
+            'last_updated' => collect([
+                $series?->updated_at,
+                $series?->edited_at,
+                $metadata->edited_at,
+                $metadata->updated_at,
+            ])->max()?->timestamp ?? 0,
         ];
     }
 

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -168,7 +168,7 @@ class PreviewGeneratorService {
         return match (true) {
             $owner instanceof Series => $owner->folder_id ? self::LEGACY_PREVIEW_PREFIX . "folders/{$owner->folder_id}.png" : null,
             $owner instanceof Metadata => ($owner->video?->folder?->path && $owner->video_id) ? self::LEGACY_PREVIEW_PREFIX . "{$owner->video?->folder?->path}/{$owner->video_id}.png" : null,
-            default => tap(null, fn() => Log::warning('PreviewGeneratorService: resolveLegacyPath called with unsupported owner', ['owner' => $owner::class, 'id' => $owner->id])),
+            default => tap(null, fn () => Log::warning('PreviewGeneratorService: resolveLegacyPath called with unsupported owner', ['owner' => $owner::class, 'id' => $owner->id])),
         };
     }
 
@@ -194,7 +194,7 @@ class PreviewGeneratorService {
             'upload_date' => $this->formatDate($series->created_at),
             'content_string' => $contentString,
             'rating' => $series->rating,
-            'tags' => $series->folder_tags ? array_map(fn($tag) => $tag->name, $series->folder_tags) : null,
+            'tags' => $series->folder_tags ? array_map(fn ($tag) => $tag->name, $series->folder_tags) : null,
             'url' => $request->fullUrl(),
             'last_updated' => strtotime($series->updated_at ?? ''),
         ];
@@ -222,7 +222,7 @@ class PreviewGeneratorService {
             'release_date' => $releaseDate,
             'upload_date' => $this->formatDate($metadata->file_modified_at),
             'mime_type' => $metadata->mime_type,
-            'tags' => $metadata->video_tags ? array_map(fn($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
+            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
             'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
             'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),
@@ -448,7 +448,7 @@ class PreviewGeneratorService {
         }
 
         // 2 decimal places
-        $formattedSize = round(($size * 100) / 100);
+        $formattedSize = round($size, 2);
 
         return "$formattedSize" . ($space ? ' ' : '') . $units[$unitIndex];
     }
@@ -491,8 +491,6 @@ class PreviewGeneratorService {
     // endregion
 }
 
-class ChromiumException extends Exception {
-}
+class ChromiumException extends Exception {}
 
-class GenerateImageException extends Exception {
-}
+class GenerateImageException extends Exception {}

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -14,8 +14,8 @@ use App\Models\Metadata;
 use App\Models\Series;
 use App\Models\SubTask;
 use App\Services\Images\ImageService;
-use Carbon\Carbon;
-use Carbon\CarbonInterval;
+use App\Services\Puppeteer\ChromiumResolver;
+use App\Support\MediaFormatter;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -32,6 +32,7 @@ class PreviewGeneratorService {
 
     public function __construct(
         protected PathResolverService $pathResolver,
+        protected ChromiumResolver $chromiumResolver,
         protected ImageService $imageService,
     ) {
         $this->defaultPoster = asset('storage/thumbnails/default.webp'); // I should use this more often???
@@ -181,7 +182,7 @@ class PreviewGeneratorService {
         $isAudio = $folder->isMajorityAudio();
         $fileCount = $series->file_count ?? 0;
         $fileType = ($isAudio ? 'Track' : 'Episode') . ($fileCount === 1 ? '' : 's');
-        $contentString = ($series->started_at ? $this->getMediaReleaseSeason($series->started_at) . ' • ' : '') . "$fileCount $fileType";
+        $contentString = ($series->started_at ? MediaFormatter::getMediaReleaseSeason($series->started_at) . ' • ' : '') . "$fileCount $fileType";
         $studio = ucfirst($series?->studio);
 
         return [
@@ -191,7 +192,7 @@ class PreviewGeneratorService {
             'is_audio' => $isAudio,
             'file_count' => $fileCount,
             'thumbnail_url' => $this->encodeImageURL($poster),
-            'upload_date' => $this->formatDate($series->created_at),
+            'upload_date' => MediaFormatter::formatDate($series->created_at),
             'content_string' => $contentString,
             'rating' => $series->rating,
             'tags' => $series->folder_tags ? array_map(fn ($tag) => $tag->name, $series->folder_tags) : null,
@@ -210,7 +211,7 @@ class PreviewGeneratorService {
         $poster = $seriesPoster ?: $this->defaultPoster;
         $banner = $metadataPoster ?: $seriesPoster ?: $this->defaultPoster;
 
-        $releaseDate = $this->formatDate($metadata->released_at ?: $metadata->file_modified_at);
+        $releaseDate = MediaFormatter::formatDate($metadata->released_at ?: $metadata->file_modified_at);
 
         return [
             'title' => ucfirst($series->title) . " · {$metadata->title}",
@@ -218,11 +219,11 @@ class PreviewGeneratorService {
             'thumbnail_url' => $this->encodeImageURL($poster),
             'banner_url' => $this->encodeImageURL($banner),
             'is_audio' => $isAudio,
-            'content_string' => $releaseDate . ' • ' . $this->formatDuration($metadata?->duration ?? null),
+            'content_string' => $releaseDate . ' • ' . MediaFormatter::formatDuration($metadata?->duration ?? null),
             'release_date' => $releaseDate,
-            'upload_date' => $this->formatDate($metadata->file_modified_at),
+            'upload_date' => MediaFormatter::formatDate($metadata->file_modified_at),
             'mime_type' => $metadata->mime_type,
-            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
+            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [MediaFormatter::formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
             'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
             'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),
@@ -272,7 +273,7 @@ class PreviewGeneratorService {
                 ->ignoreConsoleErrors()
                 ->setEnvironmentOptions(['CHROME_CONFIG_HOME' => storage_path('app/chrome/.config')]);
 
-            $this->setChromiumBinary($browsershot);
+            $browsershot = $this->chromiumResolver->setChromiumBinary($browsershot);
             $browsershot->timeout(120)->save($tempAbsolutePath);
 
             return file_get_contents($tempAbsolutePath);
@@ -309,108 +310,7 @@ class PreviewGeneratorService {
 
     // endregion
 
-    // region Puppeteer Utility
-
-    protected function canUseDocker(): bool {
-        try {
-            $dockerInfo = shell_exec('docker info --format "{{.ServerVersion}}" 2>&1');
-
-            return ! empty($dockerInfo) && ! str_contains(strtolower($dockerInfo), 'error');
-        } catch (\Throwable) {
-            return false;
-        }
-    }
-
-    protected function getPuppeteerChromiumPath(): ?string {
-        try {
-            // Determine user home directory
-            $homeDir = getenv('HOME') ?: getenv('USERPROFILE');
-            if (! $homeDir) {
-                throw new ChromiumException('Unable to resolve home directory.');
-            }
-
-            // Chromium cache path
-            $cacheDir = $homeDir . '/.cache/puppeteer/chrome';
-            if (! is_dir($cacheDir)) {
-                throw new ChromiumException("Chromium not found in Puppeteer cache: {$cacheDir}");
-            }
-
-            return $this->resolveChromiumBinary($cacheDir);
-        } catch (\Throwable $th) {
-            Log::warning('Puppeteer Chromium path not found', ['Error' => $th->getMessage()]);
-
-            return null;
-        }
-    }
-
-    protected function resolveChromiumBinary(string $baseDir): ?string {
-        try {
-            if (! is_dir($baseDir) || ! ($versions = glob($baseDir . '/*', GLOB_ONLYDIR)) || empty($versions[0])) {
-                throw new ChromiumException('Invalid chromium binary query');
-            }
-
-            foreach ($versions as $versionDir) {
-                $binary = match (PHP_OS_FAMILY) {
-                    'Windows' => $versionDir . '/chrome-win64/chrome.exe',
-                    'Darwin' => $versionDir . '/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
-                    default => $versionDir . '/chrome-linux64/chrome',
-                };
-
-                if (file_exists($binary)) {
-                    return $binary;
-                }
-            }
-
-            throw new ChromiumException('No chromium binary found');
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    protected function setChromiumBinary(Browsershot $browsershot): Browsershot {
-        if (file_exists('/run/current-system/sw/bin/chromium')) {
-            return $browsershot->setChromePath('/run/current-system/sw/bin/chromium');
-        }
-
-        if (file_exists('/usr/bin/chromium') || file_exists('/usr/bin/chromium-browser')) {
-            return $browsershot->setChromePath('/usr/bin/chromium');
-        }
-
-        if ($this->canUseDocker()) {
-            return $browsershot->useDocker();
-        }
-
-        if ($this->getPuppeteerChromiumPath()) {
-            return $browsershot;
-        }
-
-        throw new ChromiumException('No Chromium or Docker available for Browsershot.');
-    }
-
-    // endregion
-
     // region Utility
-
-    protected function getMediaReleaseSeason(?string $dateString): ?string {
-        if (! $dateString) {
-            return null;
-        }
-
-        try {
-            $date = Carbon::parse($dateString);
-
-            $season = match (true) {
-                $date->month <= 3 => 'Winter',
-                $date->month <= 6 => 'Spring',
-                $date->month <= 9 => 'Summer',
-                default => 'Fall',
-            };
-
-            return "$season {$date->year}";
-        } catch (\Throwable) {
-            return null;
-        }
-    }
 
     protected function defaultData(Request $request): array {
         return [
@@ -421,36 +321,6 @@ class PreviewGeneratorService {
             'is_audio' => false,
             'mediaUrl' => null,
         ];
-    }
-
-    protected function formatDate(?string $date, ?string $errorMessage = 'Unknown Date') {
-        return $date ? Carbon::createFromDate($date)->format('F Y') : $errorMessage;
-    }
-
-    protected function formatDuration(?int $seconds): string {
-        return $seconds ? CarbonInterval::seconds($seconds)->cascade()->forHumans(['short' => true]) : 'Unknown Duration';
-    }
-
-    /**
-     * Mimics /js/service/util.ts/formatFileSize()
-     */
-    protected function formatFileSize(int $size = 0, bool $space = true, int $divisor = 1024): string {
-        if ($size < 0) {
-            return 'Unknown size';
-        }
-
-        $unitIndex = 0;
-        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
-
-        while ($size >= $divisor && $unitIndex < count($units) - 1) {
-            $size /= $divisor;
-            $unitIndex++;
-        }
-
-        // 2 decimal places
-        $formattedSize = round($size, 2);
-
-        return "$formattedSize" . ($space ? ' ' : '') . $units[$unitIndex];
     }
 
     /**
@@ -490,7 +360,5 @@ class PreviewGeneratorService {
 
     // endregion
 }
-
-class ChromiumException extends Exception {}
 
 class GenerateImageException extends Exception {}

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -48,11 +48,11 @@ class PreviewGeneratorService {
             $videoId = $request->query('video');
 
             if ($videoId) {
-                $metadata = Metadata::where('video_id', $videoId)->firstOrFail()->load('video.folder.series.primaryPoster', 'video.folder.category', 'videoTags', 'primaryPoster');
+                $metadata = Metadata::where('video_id', $videoId)->firstOrFail()->load('video.folder.series.primaryPoster', 'video.folder.category', 'videoTags.tag', 'primaryPoster');
                 $viewData = $this->preparePreviewData($this->buildMediaPreviewData($metadata, $request), $metadata, $generateRawPreview);
             } else {
                 $category = $this->pathResolver->resolveCategory($categorySlug, ! Gate::allows('admin'));
-                $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category)->load('series.primaryPoster', 'series.folderTags');
+                $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category)->load('series.primaryPoster', 'series.folderTags.tag');
                 $viewData = $this->preparePreviewData($this->buildFolderPreviewData($category, $folder, $request), $folder->series, $generateRawPreview);
             }
 
@@ -195,7 +195,7 @@ class PreviewGeneratorService {
             'upload_date' => MediaFormatter::formatDate($series->created_at),
             'content_string' => $contentString,
             'rating' => $series->rating,
-            'tags' => $series->folder_tags ? array_map(fn ($tag) => $tag->name, $series->folder_tags) : null,
+            'tags' => $series->folderTags->pluck('tag.name')->all(),
             'url' => $request->fullUrl(),
             'last_updated' => strtotime($series->updated_at ?? ''),
         ];
@@ -223,7 +223,7 @@ class PreviewGeneratorService {
             'release_date' => $releaseDate,
             'upload_date' => MediaFormatter::formatDate($metadata->file_modified_at),
             'mime_type' => $metadata->mime_type,
-            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [MediaFormatter::formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
+            'tags' => $metadata->videoTags ? $metadata->videoTags->pluck('tag.name')->all() : [MediaFormatter::formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
             'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
             'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -52,7 +52,7 @@ class PreviewGeneratorService {
                 $viewData = $this->preparePreviewData($this->buildMediaPreviewData($metadata, $request), $metadata, $generateRawPreview);
             } else {
                 $category = $this->pathResolver->resolveCategory($categorySlug, ! Gate::allows('admin'));
-                $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category, onlyPublic: ! Gate::allows('admin'))->load('series.primaryPoster', 'series.folderTags');
+                $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category)->load('series.primaryPoster', 'series.folderTags');
                 $viewData = $this->preparePreviewData($this->buildFolderPreviewData($category, $folder, $request), $folder->series, $generateRawPreview);
             }
 

--- a/app/Services/PreviewGeneratorService.php
+++ b/app/Services/PreviewGeneratorService.php
@@ -2,47 +2,60 @@
 
 namespace App\Services;
 
-use App\Http\Resources\FolderResource;
-use App\Http\Resources\VideoResource;
-use App\Jobs\VerifyFiles;
+use App\Data\Images\ImageData;
+use App\Enums\ImageSource;
+use App\Enums\ImageType;
+use App\Enums\MediaType;
+use App\Enums\TaskStatus;
 use App\Models\Category;
 use App\Models\Folder;
+use App\Models\Image;
+use App\Models\Metadata;
+use App\Models\Series;
+use App\Models\SubTask;
+use App\Services\Images\ImageService;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Browsershot\Browsershot;
 use Symfony\Component\HttpFoundation\Response;
 
 class PreviewGeneratorService {
-    protected string $defaultThumbnail;
+    protected string $defaultPoster;
+
+    private const LEGACY_PREVIEW_PREFIX = 'previews/';
 
     public function __construct(
         protected PathResolverService $pathResolver,
+        protected ImageService $imageService,
     ) {
-        $this->defaultThumbnail = asset('storage/thumbnails/default.webp');
+        $this->defaultPoster = asset('storage/thumbnails/default.webp'); // I should use this more often???
     }
 
     public function handle(Request $request, bool $generateRawPreview): Response {
         $outputTemplate = $generateRawPreview ? 'og-media-preview' : 'og-preview';
         $defaultData = $this->defaultData($request);
+
         try {
             $categorySlug = $request->route('dir');
             $folderSlug = $request->route('folderName') ?? '';
             $videoId = $request->query('video');
 
-            $category = $this->pathResolver->resolveCategory($categorySlug, $request->user()?->id !== 1);
-            $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category)->load('series');
-
             if ($videoId) {
-                $data = $this->buildVideoPreviewData($category, $folder, $videoId, $request, $generateRawPreview);
+                $metadata = Metadata::where('video_id', $videoId)->firstOrFail()->load('video.folder.series.primaryPoster', 'video.folder.category', 'videoTags', 'primaryPoster');
+                $viewData = $this->preparePreviewData($this->buildMediaPreviewData($metadata, $request), $metadata, $generateRawPreview);
             } else {
-                $data = $this->buildFolderPreviewData($category, $folder, $request, $generateRawPreview);
+                $category = $this->pathResolver->resolveCategory($categorySlug, ! Gate::allows('admin'));
+                $folder = $this->pathResolver->resolveFolder(identifier: $folderSlug, category: $category, onlyPublic: ! Gate::allows('admin'))->load('series.primaryPoster', 'series.folderTags');
+                $viewData = $this->preparePreviewData($this->buildFolderPreviewData($category, $folder, $request), $folder->series, $generateRawPreview);
             }
 
-            return response()->view($outputTemplate, $data);
+            return response()->view($outputTemplate, $viewData);
         } catch (\Throwable $e) {
             Log::warning('Error generating link preview', [
                 'error' => $e->getMessage(),
@@ -53,103 +66,176 @@ class PreviewGeneratorService {
         }
     }
 
-    public function handleGenerateImage(array $data, string $relativePath, ?int $dataLastUpdated = 0, bool $queued = true): ?string {
+    /**
+     * Returns the path to the generated preview image
+     *
+     * Directly generates on first request and returns exisiting file on subsquent requests
+     *
+     * If the owner has been edited since the last image was generated, a new one is queued to generate.
+     */
+    protected function handleGenerateImage(Model $owner, array $data, ?int $dataLastUpdated = 0): ?string {
+        $override = config('services.preview_generator.override'); // Forces generation in local environment
+
+        $existingRow = Image::where([
+            'imageable_id' => $owner->uuid,
+            'imageable_type' => $owner::class,
+            'image_type' => ImageType::OGP,
+            'replaced_at' => null,
+        ])->first();
+
+        $legacyPath = $this->resolveLegacyPath($owner);
         $disk = Storage::disk('public');
-        $override = config('services.preview_generator.override');
-        $relativePath = trim('previews/' . $relativePath, '/') . '.png';
-        $fullPath = $disk->path($relativePath);
+        $absoluteLegacyPath = $disk->path($legacyPath);
 
-        try {
-            if (! $disk->exists($relativePath)) {
-                $queued = false;
-            } elseif (! $override && $dataLastUpdated && filemtime($fullPath) > $dataLastUpdated) {
-                return VerifyFiles::getPathUrl($relativePath);
-            }
+        $isDbStale = $existingRow && $existingRow->updated_at->timestamp < $dataLastUpdated;
+        $isFileStale = ! $existingRow && $dataLastUpdated && file_exists($absoluteLegacyPath) && filemtime($absoluteLegacyPath) < $dataLastUpdated; // Will be false if file does not exist
 
-            if (! $override && $queued) {
-                $fileJobService = app(FileJobService::class);
-                $fileJobService->regeneratePreviewImages([['data' => $data, 'path' => $relativePath]]);
-
-                return VerifyFiles::getPathUrl($relativePath);
-            }
-
-            $generatedImage = $this->generateImage($data, $relativePath);
-            if (! $generatedImage) {
-                throw new GenerateImageException('Failed to generate Image');
-            }
-
-            $disk->put($relativePath, $generatedImage);
-        } catch (\Throwable $th) { // Cannot catch the specific spatie/image exception since it throws a generic one
-            Log::warning('Error during OG image generation', ['error' => $th->getMessage()]);
+        // If not override and either db exists and is stale or file exists and is stale -> queue regenerate
+        if (! $override && ($isDbStale || $isFileStale)) {
+            $this->queueRegeneration($owner, $data);
         }
 
-        return file_exists($fullPath)
-            ? VerifyFiles::getPathUrl($relativePath)
-            : null;
+        $this->queueRegeneration($owner, $data);
+
+        if (! $override && $existingRow) {
+            return ImageService::getImageUrl($existingRow->path);
+        }
+
+        if (! $override && $disk->exists($legacyPath)) {
+            return asset('storage/' . $legacyPath);
+        }
+
+        $image = $this->generateAndPersist($owner, $data);
+
+        return $image ? ImageService::getImageUrl($image->path) : null;
     }
 
-    protected function buildFolderPreviewData(Category $category, ?Folder $folder, Request $request, bool $generateRawPreview): array {
-        $folderResource = $this->getDecodedResource(new FolderResource($folder));
-        $thumbnail = $folder->series->thumbnail_url ?: $this->defaultThumbnail;
+    /**
+     * Generates and persists a preview image for a given owner model
+     *
+     * !! Writes file to disk !!
+     *
+     * @param  Model  $owner  Owner model
+     * @param  array  $data  Preview data to fill html with
+     * @return ?Image persistent image data from database
+     */
+    public function generateAndPersist(Model $owner, array $data): ?Image {
+        try {
+            [$relativeOutputPath, $absoluteOutputPath] = $this->imageService->resolvePath($owner, ImageType::OGP, 'png');
 
-        $isAudio = $folderResource->is_majority_audio;
-        $fileCount = $folderResource->file_count ?? 0;
+            $imageContents = $this->renderImage($data); // raw png data
+
+            if (! $imageContents) {
+                throw new GenerateImageException('Browsershot returned no content');
+            }
+
+            file_put_contents($absoluteOutputPath, $imageContents);
+
+            if (! file_exists($absoluteOutputPath) || filesize($absoluteOutputPath) === 0) {
+                throw new GenerateImageException('Preview image file has no content');
+            }
+
+            return $this->imageService->persistImage(
+                $owner,
+                new ImageData(
+                    absolutePath: $absoluteOutputPath,
+                    relativePath: $relativeOutputPath,
+                    type: ImageType::OGP,
+                    source: ImageSource::GENERATED,
+                    format: 'png',
+                ),
+                true
+            );
+        } catch (\Throwable $th) {
+            Log::error('Preview image generation failed', [
+                'owner' => $owner::class,
+                'id' => $owner->getKey(),
+                'error' => $th->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Builds a legacy preview path for an owner, mirroring the previously used pathKeys in handleGenerateImage.
+     *
+     * Folder (Series): previews/folders/{folder_id}.png
+     * Video (Metadata): previews/{folder->path}/{video_id}.png
+     *
+     * @param  Model  $owner  Database Model to buld a preview path for (Metadata|Series)
+     * @return ?string path to preview image for model $owner, null if $owner model is not matched
+     */
+    protected function resolveLegacyPath(Model $owner): ?string {
+        return match (true) {
+            $owner instanceof Series => $owner->folder_id ? self::LEGACY_PREVIEW_PREFIX . "folders/{$owner->folder_id}.png" : null,
+            $owner instanceof Metadata => ($owner->video?->folder?->path && $owner->video_id) ? self::LEGACY_PREVIEW_PREFIX . "{$owner->video?->folder?->path}/{$owner->video_id}.png" : null,
+            default => tap(null, fn () => Log::warning('PreviewGeneratorService: resolveLegacyPath called with unsupported owner', ['owner' => $owner::class, 'id' => $owner->id])),
+        };
+    }
+
+    protected function buildFolderPreviewData(Category $category, ?Folder $folder, Request $request): array {
+        $series = $folder->series;
+
+        $seriesPoster = $series->primaryPoster?->path ? "storage/{$series->primaryPoster->path}" : $series->thumbnail_url;
+        $poster = $seriesPoster ?: $this->defaultPoster;
+
+        $isAudio = $folder->isMajorityAudio();
+        $fileCount = $series->file_count ?? 0;
         $fileType = ($isAudio ? 'Track' : 'Episode') . ($fileCount === 1 ? '' : 's');
-        $contentString = ($folderResource->series->started_at ? $this->getMediaReleaseSeason($folderResource->series->started_at) . ' • ' : '') . "$fileCount $fileType";
-        $studio = ucfirst($folderResource?->series?->studio);
+        $contentString = ($series->started_at ? $this->getMediaReleaseSeason($series->started_at) . ' • ' : '') . "$fileCount $fileType";
+        $studio = ucfirst($series?->studio);
 
-        $data = [
-            'title' => "{$folderResource->series->title}",
-            'description' => $folderResource->series->description ?: 'No description is available.',
+        return [
+            'title' => "{$series->title}",
+            'description' => $series->description ?: 'No description is available.',
             'studio' => ($studio ? $studio . ' · ' : '') . ucfirst($category->name),
             'is_audio' => $isAudio,
-            'file_count' => $folderResource->file_count,
-            'thumbnail_url' => $this->encodeImageURL($thumbnail),
-            'upload_date' => $this->formatDate($folderResource->series->created_at),
+            'file_count' => $fileCount,
+            'thumbnail_url' => $this->encodeImageURL($poster),
+            'upload_date' => $this->formatDate($series->created_at),
             'content_string' => $contentString,
-            'rating' => $folderResource->series->rating,
-            'tags' => $folderResource->series->folder_tags ? array_map(fn ($tag) => $tag->name, $folderResource->series->folder_tags) : null,
+            'rating' => $series->rating,
+            'tags' => $series->folder_tags ? array_map(fn ($tag) => $tag->name, $series->folder_tags) : null,
             'url' => $request->fullUrl(),
+            'last_updated' => strtotime($series->updated_at ?? ''),
         ];
-
-        return $this->preparePreviewData($data, "folders/{$folder->id}", strtotime($folderResource->series?->updated_at ?? ''), $generateRawPreview);
     }
 
-    protected function buildVideoPreviewData(Category $category, ?Folder $folder, string $videoId, Request $request, bool $generateRawPreview): array {
-        $folderResource = $this->getDecodedResource(new FolderResource($folder->load('series.primaryPoster')));
-        $video = $folder->videos()->findOrFail($videoId);
-        $videoResource = $this->getDecodedResource(new VideoResource($video->load('metadata.videoTags', 'metadata.primaryPoster')));
+    protected function buildMediaPreviewData(Metadata $metadata, Request $request) {
+        $series = $metadata->video->folder->series;
+        $isAudio = $metadata->media_type === MediaType::AUDIO;
 
-        $isAudio = str_starts_with($videoResource->metadata?->mime_type, 'audio');
-        $thumbnail = $videoResource->metadata->poster_url ?: $folder->series->thumbnail_url ?: $this->defaultThumbnail;
+        // Poster for music does not auto migrate?
+        $metadataPoster = $metadata->primaryPoster?->path ? "storage/{$metadata->primaryPoster->path}" : $metadata->poster_url; // Backwards Compatible
+        $seriesPoster = $series->primaryPoster?->path ? "storage/{$series->primaryPoster->path}" : $series->thumbnail_url;
+        $poster = $seriesPoster ?: $this->defaultPoster;
+        $banner = $metadataPoster ?: $seriesPoster ?: $this->defaultPoster;
 
-        $releaseDate = $this->formatDate($video->metadata->released_at ?: $video->metadata->file_modified_at);
-        $contentString = $releaseDate . ' • ' . $this->formatDuration($videoResource?->metadata?->duration ?? null);
+        $releaseDate = $this->formatDate($metadata->released_at ?: $metadata->file_modified_at);
 
-        $folderDateUpdated = strtotime($folderResource->series->updated_at);
-        $videoDateUpdated = strtotime($videoResource->updated_at ?? '') ?: 0;
-        $latestTimestamp = max($folderDateUpdated, $videoDateUpdated);
-        $data = [
-            'title' => ucfirst($folderResource->series->title) . " · {$video->metadata->title}",
-            'description' => $video->metadata->description ?: $folderResource->series->description ?: 'No description is available.',
-            'thumbnail_url' => $this->encodeImageURL($thumbnail),
+        return [
+            'title' => ucfirst($series->title) . " · {$metadata->title}",
+            'description' => $metadata->description ?: $series->description ?: 'No description is available.',
+            'thumbnail_url' => $this->encodeImageURL($poster),
+            'banner_url' => $this->encodeImageURL($banner),
             'is_audio' => $isAudio,
-            'content_string' => $contentString,
+            'content_string' => $releaseDate . ' • ' . $this->formatDuration($metadata?->duration ?? null),
             'release_date' => $releaseDate,
-            'upload_date' => $this->formatDate($video->metadata->file_modified_at),
-            'mime_type' => $video->mime_type,
-            'tags' => $videoResource->video_tags ? array_map(fn ($tag) => $tag->name, $videoResource->video_tags) : null,
-            'studio' => ucfirst($folderResource?->series?->studio ?? $category->name),
+            'upload_date' => $this->formatDate($metadata->file_modified_at),
+            'mime_type' => $metadata->mime_type,
+            'tags' => $metadata->video_tags ? array_map(fn ($tag) => $tag->name, $metadata->video_tags) : [$this->formatFileSize($metadata->file_size), "{$metadata->resolution_height}P", strtoupper($metadata->codec)],
+            'studio' => ucfirst($series?->studio ?? $metadata->video->folder->category->name),
             'url' => $request->fullUrl(),
+            'last_updated' => max(strtotime($series->updated_at), strtotime($metadata->updated_at ?? '') ?: 0),
         ];
-
-        return $this->preparePreviewData($data, "{$folder->path}/{$video->id}", $latestTimestamp, $generateRawPreview);
     }
 
-    protected function preparePreviewData(array $baseData, string $pathKey, ?int $dataLastUpdated, bool $generateRawPreview): array {
+    protected function preparePreviewData(array $baseData, Model $owner, bool $generateRawPreview): array {
+        $dataLastUpdated = $baseData['last_updated'] ?? 0;
         $baseData['raw'] = $baseData['thumbnail_url'];
 
-        if (! $generateRawPreview && $generatedImage = $this->handleGenerateImage($baseData, $pathKey, $dataLastUpdated)) {
+        if (! $generateRawPreview && $generatedImage = $this->handleGenerateImage($owner, $baseData, $dataLastUpdated)) {
             $baseData['thumbnail_url'] = $generatedImage;
             $baseData['is_generated'] = true;
         }
@@ -157,144 +243,52 @@ class PreviewGeneratorService {
         return $baseData;
     }
 
-    public function generateImage(array $data, string $relativePath, bool $selfStore = false) {
+    // region Rendering / Browsershot
+
+    /**
+     * Renders preview image and returns raw png data
+     */
+    protected function renderImage(array $data): string|false {
+        $tempRelativePath = 'cache/render-artifacts/previews/' . uniqid('og-', true) . '.png'; // TODO: use configured cache path
+        $tempAbsolutePath = Storage::path($tempRelativePath);
+        Storage::makeDirectory(dirname($tempRelativePath));
+
         try {
-            $tempRelativePath = 'previews/' . uniqid('og-', true) . '.png';
-            $tempPath = Storage::disk('public')->path($tempRelativePath);
-
-            Storage::disk('public')->makeDirectory(dirname($relativePath));
-
-            $chromeUserDataDir = storage_path('app/chrome');
-            $chromeConfigHome = storage_path('app/chrome/.config');
-
             $html = $this->generatePreviewPage($data);
-            $browsershot = Browsershot::html($html)->windowSize(1200, 630)
+
+            $browsershot = Browsershot::html($html)
+                ->windowSize(1200, 630)
                 ->deviceScaleFactor(2)
-                ->waitUntilNetworkIdle()->setOption('args', [
+                ->waitUntilNetworkIdle()
+                ->setOption('args', [
                     '--disable-gpu',
                     '--no-sandbox',
                     '--disable-setuid-sandbox',
                     '--disable-dev-shm-usage',
-                    "--user-data-dir=$chromeUserDataDir",
+                    '--user-data-dir=' . storage_path('app/chrome'),
                     '--disable-web-security',
                     '--font-render-hinting=none',
                     '--enable-features=NetworkService,NetworkServiceInProcess',
                     '--blink-settings=imagesEnabled=true',
                 ])
-                ->ignoreConsoleErrors()->setEnvironmentOptions([
-                    'CHROME_CONFIG_HOME' => $chromeConfigHome,
-                ]);
+                ->ignoreConsoleErrors()
+                ->setEnvironmentOptions(['CHROME_CONFIG_HOME' => storage_path('app/chrome/.config')]);
 
-            $browsershot = $this->setChromiumBinary($browsershot);
-            $browsershot->timeout(120)->save($tempPath);
+            $this->setChromiumBinary($browsershot);
+            $browsershot->timeout(120)->save($tempAbsolutePath);
 
-            $imageContents = file_get_contents($tempPath);
-            Storage::disk('public')->delete($tempRelativePath);
-
-            $result = $imageContents;
-
-            if ($selfStore) {
-                Storage::disk('public')->put($relativePath, $imageContents);
-                $result = VerifyFiles::getPathUrl($relativePath);
-            }
-
-            return $result;
-        } catch (\Throwable $th) { // Cannot catch the specific spatie/image exception since it throws a generic one
+            return file_get_contents($tempAbsolutePath);
+        } catch (\Throwable $th) {
             $message = $th->getMessage();
 
             if ($message !== 'The spatie/image package is required to perform image manipulations. Please install it by running `composer require spatie/image`') {
-                Log::error('Error during OG image generation', ['error' => $th->getMessage(), 'trace' => $th->getTraceAsString()]);
+                Log::error('Browsershot render failed', ['error' => $message, 'trace' => $th->getTraceAsString()]);
             }
 
-            if (file_exists($tempPath)) {
-                $imageContents = file_get_contents($tempPath);
-                Storage::disk('public')->delete($tempRelativePath);
-            }
-
-            if (! $selfStore || ! isset($imageContents)) {
-                return $imageContents ?? false;
-            }
-
-            Storage::disk('public')->put($relativePath, $imageContents);
-
-            return VerifyFiles::getPathUrl($relativePath);
+            return file_exists($tempAbsolutePath) ? file_get_contents($tempAbsolutePath) : false;
+        } finally {
+            Storage::delete($tempRelativePath);
         }
-    }
-
-    protected function canUseDocker(): bool {
-        try {
-            $dockerInfo = shell_exec('docker info --format "{{.ServerVersion}}" 2>&1');
-
-            return ! empty($dockerInfo) && ! str_contains(strtolower($dockerInfo), 'error');
-        } catch (\Throwable $e) {
-            return false;
-        }
-    }
-
-    protected function getPuppeteerChromiumPath(): string {
-        try {
-            // Determine user home directory
-            $homeDir = getenv('HOME') ?: getenv('USERPROFILE');
-            if (! $homeDir) {
-                throw new ChromiumException('Unable to resolve home directory.');
-            }
-
-            // Chromium cache path
-            $cacheDir = $homeDir . '/.cache/puppeteer/chrome';
-            if (! is_dir($cacheDir)) {
-                throw new ChromiumException("Chromium not found in Puppeteer cache: {$cacheDir}");
-            }
-
-            return $this->resolveChromiumBinary($cacheDir);
-        } catch (\Throwable $th) {
-            Log::warning('Puppeteer Chromium path not found', ['Error' => $th->getMessage()]);
-
-            return '';
-        }
-    }
-
-    protected function resolveChromiumBinary(string $baseDir): ?string {
-        try {
-            $platform = PHP_OS_FAMILY;
-
-            if (! is_dir($baseDir) || ! ($versions = glob($baseDir . '/*', GLOB_ONLYDIR)) || empty($versions[0])) {
-                throw new ChromiumException('Invalid chromium binary query');
-            }
-
-            foreach ($versions as $versionDir) {
-                $binary = match ($platform) {
-                    'Windows' => $versionDir . '/chrome-win64/chrome.exe',
-                    'Darwin' => $versionDir . '/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
-                    default => $versionDir . '/chrome-linux64/chrome',
-                };
-
-                if (! file_exists($binary)) {
-                    throw new ChromiumException("Chromium binary not found at: {$binary}");
-                }
-
-                return $binary;
-            }
-
-            throw new ChromiumException('No chromium binary found');
-        } catch (\Throwable $th) {
-            return null;
-        }
-    }
-
-    public function setChromiumBinary(Browsershot $browsershot) {
-        if (file_exists('/run/current-system/sw/bin/chromium')) {
-            $browsershot->setChromePath('/run/current-system/sw/bin/chromium');
-        } elseif (file_exists('/usr/bin/chromium') || file_exists('/usr/bin/chromium-browser')) {
-            $browsershot->setChromePath('/usr/bin/chromium');
-        } elseif ($this->canUseDocker()) {
-            $browsershot->useDocker();
-        } elseif ($this->getPuppeteerChromiumPath()) {
-            return $browsershot;
-        } else {
-            throw new ChromiumException('No Chromium or Docker available for Browsershot.');
-        }
-
-        return $browsershot;
     }
 
     protected function generatePreviewPage(array $data): string {
@@ -315,6 +309,90 @@ class PreviewGeneratorService {
         return $html;
     }
 
+    // endregion
+
+    // region Puppeteer Utility
+
+    protected function canUseDocker(): bool {
+        try {
+            $dockerInfo = shell_exec('docker info --format "{{.ServerVersion}}" 2>&1');
+
+            return ! empty($dockerInfo) && ! str_contains(strtolower($dockerInfo), 'error');
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    protected function getPuppeteerChromiumPath(): ?string {
+        try {
+            // Determine user home directory
+            $homeDir = getenv('HOME') ?: getenv('USERPROFILE');
+            if (! $homeDir) {
+                throw new ChromiumException('Unable to resolve home directory.');
+            }
+
+            // Chromium cache path
+            $cacheDir = $homeDir . '/.cache/puppeteer/chrome';
+            if (! is_dir($cacheDir)) {
+                throw new ChromiumException("Chromium not found in Puppeteer cache: {$cacheDir}");
+            }
+
+            return $this->resolveChromiumBinary($cacheDir);
+        } catch (\Throwable $th) {
+            Log::warning('Puppeteer Chromium path not found', ['Error' => $th->getMessage()]);
+
+            return null;
+        }
+    }
+
+    protected function resolveChromiumBinary(string $baseDir): ?string {
+        try {
+            if (! is_dir($baseDir) || ! ($versions = glob($baseDir . '/*', GLOB_ONLYDIR)) || empty($versions[0])) {
+                throw new ChromiumException('Invalid chromium binary query');
+            }
+
+            foreach ($versions as $versionDir) {
+                $binary = match (PHP_OS_FAMILY) {
+                    'Windows' => $versionDir . '/chrome-win64/chrome.exe',
+                    'Darwin' => $versionDir . '/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
+                    default => $versionDir . '/chrome-linux64/chrome',
+                };
+
+                if (file_exists($binary)) {
+                    return $binary;
+                }
+            }
+
+            throw new ChromiumException('No chromium binary found');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    protected function setChromiumBinary(Browsershot $browsershot): Browsershot {
+        if (file_exists('/run/current-system/sw/bin/chromium')) {
+            return $browsershot->setChromePath('/run/current-system/sw/bin/chromium');
+        }
+
+        if (file_exists('/usr/bin/chromium') || file_exists('/usr/bin/chromium-browser')) {
+            return $browsershot->setChromePath('/usr/bin/chromium');
+        }
+
+        if ($this->canUseDocker()) {
+            return $browsershot->useDocker();
+        }
+
+        if ($this->getPuppeteerChromiumPath()) {
+            return $browsershot;
+        }
+
+        throw new ChromiumException('No Chromium or Docker available for Browsershot.');
+    }
+
+    // endregion
+
+    // region Utility
+
     protected function getMediaReleaseSeason(?string $dateString): ?string {
         if (! $dateString) {
             return null;
@@ -322,14 +400,15 @@ class PreviewGeneratorService {
 
         try {
             $date = Carbon::parse($dateString);
+
             $season = match (true) {
-                $date->month >= 1 && $date->month <= 3 => 'Winter ',
-                $date->month >= 4 && $date->month <= 6 => 'Spring ',
-                $date->month >= 7 && $date->month <= 9 => 'Summer ',
-                default => 'Fall ',
+                $date->month <= 3 => 'Winter',
+                $date->month <= 6 => 'Spring',
+                $date->month <= 9 => 'Summer',
+                default => 'Fall',
             };
 
-            return $season . $date->year;
+            return "$season {$date->year}";
         } catch (\Throwable) {
             return null;
         }
@@ -339,42 +418,79 @@ class PreviewGeneratorService {
         return [
             'title' => 'Media Server',
             'description' => 'An auto-generated preview for bots.',
-            'thumbnail_url' => $this->defaultThumbnail,
+            'thumbnail_url' => $this->defaultPoster,
             'url' => $request->fullUrl(),
             'is_audio' => false,
             'mediaUrl' => null,
         ];
     }
 
-    protected function getDecodedResource($resource) {
-        return json_decode(json_encode($resource));
-    }
-
     protected function formatDate(?string $date, ?string $errorMessage = 'Unknown Date') {
-        if (! $date) {
-            return $errorMessage;
-        }
-
-        return Carbon::createFromDate($date)->format('F Y');
+        return $date ? Carbon::createFromDate($date)->format('F Y') : $errorMessage;
     }
 
-    protected function formatDuration(?int $seconds) {
-        if (! $seconds) {
-            return 'Unknown Duration';
-        }
-
-        return CarbonInterval::seconds($seconds)->cascade()->forHumans([
-            'short' => true,
-        ]);
+    protected function formatDuration(?int $seconds): string {
+        return $seconds ? CarbonInterval::seconds($seconds)->cascade()->forHumans(['short' => true]) : 'Unknown Duration';
     }
 
+    /**
+     * Mimics /js/service/util.ts/formatFileSize()
+     */
+    protected function formatFileSize(int $size = 0, bool $space = true, int $divisor = 1024): string {
+        if ($size < 0) {
+            return 'Unknown size';
+        }
+
+        $unitIndex = 0;
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+        while ($size >= $divisor && $unitIndex < count($units) - 1) {
+            $size /= $divisor;
+            $unitIndex++;
+        }
+
+        // 2 decimal places
+        $formattedSize = round(($size * 100) / 100);
+
+        return "$formattedSize" . ($space ? ' ' : '') . $units[$unitIndex];
+    }
+
+    /**
+     * Returns an encoded url for a given image
+     *
+     * Converts to an asset url if the given url is relative in app storage
+     *
+     * @param  string  $url  Image URL
+     * @return string Encoded Image URL
+     */
     protected function encodeImageURL(string $url): string {
-        if (! filter_var($url, FILTER_VALIDATE_URL) && str_starts_with($url, '/storage')) {
-            $url = config('app.url') . $url;
+        if (! filter_var($url, FILTER_VALIDATE_URL) && str_starts_with($url, 'storage/')) {
+            $url = asset($url);
         }
 
         return str_replace([chr(39), chr(34), ' '], ['%27', '%22', '%20'], $url);
     }
+
+    // endregion
+
+    // region Side Effects
+
+    protected function queueRegeneration(Model $owner, array $data): void {
+        $alreadyRunning = SubTask::where('reference_uuid', $owner->uuid)
+            ->where('reference_type', ImageType::OGP)
+            ->whereIn('status', [TaskStatus::PENDING, TaskStatus::PROCESSING])
+            ->latest()
+            ->first();
+
+        if ($alreadyRunning) {
+            return;
+        } // Don't duplicate regeneration jobs (maybe use date to determine stale jobs in progress?)
+
+        $fileJobService = app(FileJobService::class);
+        $fileJobService->regeneratePreviewImages([['owner' => $owner, 'data' => $data]]);
+    }
+
+    // endregion
 }
 
 class ChromiumException extends Exception {}

--- a/app/Services/Puppeteer/ChromiumResolver.php
+++ b/app/Services/Puppeteer/ChromiumResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services\Puppeteer;
+
+use Exception;
+use Illuminate\Support\Facades\Log;
+use Spatie\Browsershot\Browsershot;
+
+class ChromiumResolver {
+    protected function canUseDocker(): bool {
+        try {
+            $dockerInfo = shell_exec('docker info --format "{{.ServerVersion}}" 2>&1');
+
+            return ! empty($dockerInfo) && ! str_contains(strtolower($dockerInfo), 'error');
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    protected function getPuppeteerChromiumPath(): ?string {
+        try {
+            // Determine user home directory
+            $homeDir = getenv('HOME') ?: getenv('USERPROFILE');
+            if (! $homeDir) {
+                throw new ChromiumException('Unable to resolve home directory.');
+            }
+
+            // Chromium cache path
+            $cacheDir = $homeDir . '/.cache/puppeteer/chrome';
+            if (! is_dir($cacheDir)) {
+                throw new ChromiumException("Chromium not found in Puppeteer cache: {$cacheDir}");
+            }
+
+            return $this->resolveChromiumBinary($cacheDir);
+        } catch (\Throwable $th) {
+            Log::warning('Puppeteer Chromium path not found', ['Error' => $th->getMessage()]);
+
+            return null;
+        }
+    }
+
+    protected function resolveChromiumBinary(string $baseDir): ?string {
+        try {
+            if (! is_dir($baseDir) || ! ($versions = glob($baseDir . '/*', GLOB_ONLYDIR)) || empty($versions[0])) {
+                throw new ChromiumException('Invalid chromium binary query');
+            }
+
+            foreach ($versions as $versionDir) {
+                $binary = match (PHP_OS_FAMILY) {
+                    'Windows' => $versionDir . '/chrome-win64/chrome.exe',
+                    'Darwin' => $versionDir . '/chrome-mac/Chromium.app/Contents/MacOS/Chromium',
+                    default => $versionDir . '/chrome-linux64/chrome',
+                };
+
+                if (file_exists($binary)) {
+                    return $binary;
+                }
+            }
+
+            throw new ChromiumException('No chromium binary found');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public function setChromiumBinary(Browsershot $browsershot): Browsershot {
+        if (file_exists('/run/current-system/sw/bin/chromium')) {
+            return $browsershot->setChromePath('/run/current-system/sw/bin/chromium');
+        }
+
+        if (file_exists('/usr/bin/chromium') || file_exists('/usr/bin/chromium-browser')) {
+            return $browsershot->setChromePath('/usr/bin/chromium');
+        }
+
+        if ($this->canUseDocker()) {
+            return $browsershot->useDocker();
+        }
+
+        if ($this->getPuppeteerChromiumPath()) {
+            return $browsershot;
+        }
+
+        throw new ChromiumException('No Chromium or Docker available for Browsershot.');
+    }
+}
+
+class ChromiumException extends Exception {}

--- a/app/Support/MediaFormatter.php
+++ b/app/Support/MediaFormatter.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterval;
+
+class MediaFormatter {
+    public static function getMediaReleaseSeason(?string $dateString): ?string {
+        if (! $dateString) {
+            return null;
+        }
+
+        try {
+            $date = Carbon::parse($dateString);
+
+            $season = match (true) {
+                $date->month <= 3 => 'Winter',
+                $date->month <= 6 => 'Spring',
+                $date->month <= 9 => 'Summer',
+                default => 'Fall',
+            };
+
+            return "$season {$date->year}";
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public static function formatDate(?string $date, ?string $errorMessage = 'Unknown Date') {
+        return $date ? Carbon::createFromDate($date)->format('F Y') : $errorMessage;
+    }
+
+    public static function formatDuration(?int $seconds): string {
+        return $seconds ? CarbonInterval::seconds($seconds)->cascade()->forHumans(['short' => true]) : 'Unknown Duration';
+    }
+
+    /**
+     * Mimics /js/service/util.ts/formatFileSize()
+     */
+    public static function formatFileSize(int $size = 0, bool $space = true, int $divisor = 1024): string {
+        if ($size < 0) {
+            return 'Unknown size';
+        }
+
+        $unitIndex = 0;
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+        while ($size >= $divisor && $unitIndex < count($units) - 1) {
+            $size /= $divisor;
+            $unitIndex++;
+        }
+
+        // 2 decimal places
+        $formattedSize = round($size, 2);
+
+        return "$formattedSize" . ($space ? ' ' : '') . $units[$unitIndex];
+    }
+}

--- a/database/migrations/2026_06_06_195825_change_image_type_and_source_enums_to_strings_on_images.php
+++ b/database/migrations/2026_06_06_195825_change_image_type_and_source_enums_to_strings_on_images.php
@@ -1,0 +1,107 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    private array $imageTypeMap = [
+        0 => 'poster',
+        1 => 'banner',
+        2 => 'avatar',
+    ];
+
+    private array $imageSourceMap = [
+        0 => 'generated',
+        1 => 'uploaded',
+        2 => 'api',
+        3 => 'url',
+        4 => 'downloaded',
+        5 => 'embedded',
+        6 => 'legacy',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('images', function (Blueprint $table) {
+            $table->string('image_type_str', 50)->nullable();
+            $table->string('image_source_str', 50)->nullable();
+        });
+
+        foreach ($this->imageTypeMap as $int => $str) {
+            DB::table('images')->where('image_type', $int)->update(['image_type_str' => $str]);
+        }
+
+        foreach ($this->imageSourceMap as $int => $str) {
+            DB::table('images')->where('image_source', $int)->update(['image_source_str' => $str]);
+        }
+
+        $unmappedType = DB::table('images')->whereNull('image_type_str')->count();
+        $unmappedSource = DB::table('images')->whereNull('image_source_str')->count();
+
+        if ($unmappedType > 0 || $unmappedSource > 0) {
+            // abort if some entries failed to copy over
+            Schema::table('images', function (Blueprint $table) {
+                $table->dropColumn(['image_type_str', 'image_source_str']);
+            });
+
+            throw new \RuntimeException(
+                "Migration aborted: {$unmappedType} unmapped image_type rows, {$unmappedSource} unmapped image_source rows."
+            );
+        }
+
+        Schema::table('images', function (Blueprint $table) {
+            $table->dropColumn(['image_type', 'image_source']);
+        });
+
+        Schema::table('images', function (Blueprint $table) {
+            $table->renameColumn('image_type_str', 'image_type');
+            $table->renameColumn('image_source_str', 'image_source');
+        });
+
+        // make not nullable
+        Schema::table('images', function (Blueprint $table) {
+            $table->string('image_type')->change();
+            $table->string('image_source')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        $imageTypeMap = array_flip($this->imageTypeMap);
+        $imageSourceMap = array_flip($this->imageSourceMap);
+
+        Schema::table('images', function (Blueprint $table) {
+            $table->smallInteger('image_type_int')->nullable();
+            $table->smallInteger('image_source_int')->nullable();
+        });
+
+        foreach ($imageTypeMap as $str => $int) {
+            DB::table('images')->where('image_type', $str)->update(['image_type_int' => $int]);
+        }
+
+        foreach ($imageSourceMap as $str => $int) {
+            DB::table('images')->where('image_source', $str)->update(['image_source_int' => $int]);
+        }
+
+        Schema::table('images', function (Blueprint $table) {
+            $table->dropColumn(['image_type', 'image_source']);
+        });
+
+        Schema::table('images', function (Blueprint $table) {
+            $table->renameColumn('image_type_int', 'image_type');
+            $table->renameColumn('image_source_int', 'image_source');
+        });
+
+        // make not nullable
+        Schema::table('images', function (Blueprint $table) {
+            $table->smallInteger('image_type')->change();
+            $table->smallInteger('image_source')->change();
+        });
+    }
+};

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -1313,11 +1313,16 @@ defineExpose({
     <div v-if="isTheatreView" class="pointer-events-none aspect-video w-full rounded-lg bg-black/30" />
     <div
         :class="
-            cn('relative overflow-clip', 'text-xs', {
-                'theatre-mode player-transition animate-theatre-enter': isTheatreView,
-                'rounded-lg': isNormalView,
-                'rounded-sm': isFullScreen,
-            })
+            cn(
+                'relative overflow-clip',
+                'text-xs',
+                {
+                    'theatre-mode player-transition animate-theatre-enter': isTheatreView,
+                    'rounded-lg': isNormalView,
+                    'rounded-sm': isFullScreen,
+                },
+                isShowingControls ? 'cursor-auto' : 'cursor-none!',
+            )
         "
         ref="player-container"
         id="player-container"
@@ -1346,11 +1351,10 @@ defineExpose({
                 :style="{ '--subtitle-font-multiplier': playerSubtitles?.subtitleSizeMultiplier ?? 1 }"
                 :class="
                     cn(
-                        `absolute size-full cursor-none object-contain select-none focus:outline-hidden`,
+                        `absolute size-full object-contain select-none focus:outline-hidden`,
                         { 'static z-3': !isAudio && (!posterUrl || (posterUrl && isThumbnailDismissed)) }, // Force position if no poster exists
                         { 'bg-black': !isAudio && !aspectRatio.isAspectVideo }, // Black bg when video does not fill aspect-video
                         isPlayerSizeConstrained ? 'max-h-[71vh]' : 'aspect-video', // Force 16:9 for all non portrait video (reduces cls and uncertainty)
-                        { 'cursor-auto': isShowingControls },
                         isFullScreen || isTheatreView
                             ? '[--subtitle-cue-size:1.2rem] [--subtitle-font-size:180%]'
                             : '[--subtitle-cue-size:0.8em] [--subtitle-font-size:100%] sm:[--subtitle-font-size:136%]',

--- a/resources/js/contracts/media.ts
+++ b/resources/js/contracts/media.ts
@@ -84,6 +84,7 @@ export interface MetadataResource {
 
     poster_url?: string;
     poster_image?: ImageResource;
+    images?: ImageResource[];
 
     artist?: string;
     album?: string;
@@ -169,6 +170,8 @@ export interface StoryboardResource {
 export interface ImageResource {
     id: number;
     path: string;
+    type: string;
+    source: string;
     blurHash?: string;
 }
 

--- a/resources/views/og-media-preview.blade.php
+++ b/resources/views/og-media-preview.blade.php
@@ -40,7 +40,7 @@
                 </span>
 
                 <div class="flex items-center gap-3">
-                    <div class="flex overflow-hidden w-full gap-3 flex-wrap h-9 [overflow-clip-margin:4px]">
+                    <div class="flex overflow-hidden w-full gap-2 flex-wrap h-9 [overflow-clip-margin:4px]">
                         @foreach (collect($tags ?? ['no tags yet'])->take(5) as $tag)
                         <span class="bg-white/10 px-3 py-1 rounded-full text-nowrap">{{ $tag }}</span>
                         @endforeach

--- a/resources/views/og-media-preview.blade.php
+++ b/resources/views/og-media-preview.blade.php
@@ -41,7 +41,7 @@
 
                 <div class="flex items-center gap-3">
                     <div class="flex overflow-hidden w-full gap-2 flex-wrap h-9 [overflow-clip-margin:4px]">
-                        @foreach (collect($tags ?? ['no tags yet'])->take(5) as $tag)
+                        @foreach (collect(count($tags) > 0 ? $tags : ['no tags yet'])->take(5) as $tag)
                         <span class="bg-white/10 px-3 py-1 rounded-full text-nowrap">{{ $tag }}</span>
                         @endforeach
                     </div>


### PR DESCRIPTION
### Fixes

- Cursor remains over player after controls are hidden
- Storyboard fails for extremely short videos

### Changes

- Generate previews in `/metadata/{owner}/{shard}/{uuid}/preview.png instead` of `/previews`
- Changed image_type and image_source enums to strings

### Additions

- Use generated posters in previews
- Track preview images in db

### Demo

- Incorperate generated posters into opg
  <img width="885" height="601" alt="image" src="https://github.com/user-attachments/assets/e7e45bf2-06c2-458d-bcf8-ea0626ad498e" />

