### PR TITLE
Fix/context menu perf

### DIFF
--- a/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
@@ -124,7 +124,7 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
         enter-active-class="ease-out duration-150"
         enter-from-class="scale-80 opacity-0"
         enter-to-class="scale-100 opacity-100"
-        leave-active-class="ease-in-out duration-100"
+        leave-active-class="ease-in duration-100"
         leave-from-class="scale-100 opacity-100"
         leave-to-class="scale-60 opacity-0"
     >

--- a/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
@@ -21,69 +21,84 @@ const menuStyles = ref<Record<string, string>>({});
 
 const { isOutside } = useMouseInElement(contextMenu);
 
-const contextMenuToggle = async (event: any, override: boolean = true) => {
+let lastEvent: MouseEvent | null = null;
+
+const contextMenuToggle = async (event: MouseEvent, override: boolean = true) => {
     if (!override || props.disabled) {
-        document.removeEventListener('contextmenu', closeContextMenu);
         contextMenuOpen.value = false;
         return;
     }
 
-    if (!contextMenuOpen.value) {
-        document.addEventListener('contextmenu', closeContextMenu);
-        contextMenuOpen.value = true;
-    }
-
+    // Native context menu only runs if disabled
     event.preventDefault();
     event.stopPropagation();
 
-    contextMenu.value?.$el.classList.add('opacity-0');
+    // always close first if open, then reopen fresh — matches native explorer behaviour
+    if (contextMenuOpen.value) {
+        contextMenuOpen.value = false;
+        await nextTick();
+    }
 
-    await nextTick(() => {
-        calculateContextMenuPosition(event);
-        calculateSubMenuPosition(event);
-        contextMenu.value?.$el.classList.remove('opacity-0');
-    });
+    if (lastEvent?.clientX === event.clientX && lastEvent?.clientY === event.clientY && lastEvent?.target === event.target) {
+        lastEvent = null;
+        return;
+    }
+
+    contextMenuOpen.value = true;
+    lastEvent = event;
+
+    await nextTick();
+
+    calculateContextMenuPosition(event);
+    calculateSubMenuPosition(event);
 };
 
-function calculateContextMenuPosition(clickEvent: MouseEvent) {
-    if (!contextMenu.value) return;
+function calculateContextMenuPosition(event: MouseEvent) {
+    const el = contextMenu.value?.$el as HTMLElement | undefined;
+    if (!el) return;
 
     const scrollY = props.scrollContainer === 'body' ? document.body.scrollTop : window.scrollY;
     const scrollX = props.scrollContainer === 'body' ? document.body.scrollLeft : window.scrollX;
 
-    if (window.innerHeight < clickEvent.clientY + contextMenu.value?.$el.offsetHeight) {
-        contextMenu.value.$el.style.top = window.innerHeight - contextMenu.value?.$el.offsetHeight + scrollY + 'px';
-    } else {
-        contextMenu.value.$el.style.top = clickEvent.clientY + scrollY + 'px';
-    }
-    if (window.innerWidth < clickEvent.clientX + contextMenu.value?.$el.offsetWidth) {
-        contextMenu.value.$el.style.left = clickEvent.clientX - contextMenu.value?.$el.offsetWidth + scrollX + 'px';
-    } else {
-        contextMenu.value.$el.style.left = clickEvent.clientX + 'px';
-    }
+    const overflowsBottom = event.clientY + el.offsetHeight > window.innerHeight;
+    const overflowsRight = event.clientX + el.offsetWidth > window.innerWidth;
+
+    el.style.top = Math.max(overflowsBottom ? window.innerHeight - el.offsetHeight : event.clientY, 0) + scrollY + 'px';
+    el.style.left = Math.max((overflowsRight ? event.clientX - el.offsetWidth : event.clientX) + scrollX, 0) + 'px';
 }
 
-async function calculateSubMenuPosition(clickEvent: MouseEvent) {
+async function calculateSubMenuPosition(event: MouseEvent) {
     await nextTick();
-    const submenus: NodeListOf<HTMLElement> = document.querySelectorAll('[data-submenu]');
-    const contextMenuWidth = contextMenu.value?.$el.offsetWidth;
+
+    const el = contextMenu.value?.$el as HTMLElement | undefined;
+    if (!el) return;
+
+    const submenus = document.querySelectorAll<HTMLElement>('[data-submenu]');
+    const menuRight = event.clientX + el.offsetWidth;
 
     for (const submenu of submenus) {
-        if (window.innerWidth < clickEvent.clientX + contextMenuWidth + submenu.offsetWidth) {
-            submenu.classList.add('left-0', '-translate-x-full');
-            submenu.classList.remove('right-0', 'translate-x-full');
-        } else {
-            submenu.classList.remove('left-0', '-translate-x-full');
-            submenu.classList.add('right-0', 'translate-x-full');
+        const overflowsRight = menuRight + submenu.offsetWidth > window.innerWidth;
+        const overflowsLeft = el.offsetLeft - submenu.offsetWidth < 0;
+
+        const floating = !(overflowsLeft && overflowsRight);
+        submenu.dataset.floating = String(floating);
+
+        submenu.classList.toggle('left-0', overflowsRight);
+        submenu.classList.toggle('-translate-x-full', overflowsRight && !overflowsLeft);
+        submenu.classList.toggle('right-0', !overflowsRight);
+        submenu.classList.toggle('translate-x-full', !overflowsRight);
+        submenu.classList.toggle('floating-menu', floating);
+
+        const triggerRect = submenu.previousElementSibling?.getBoundingClientRect();
+        const overflowsBottom = triggerRect && triggerRect.top + submenu.offsetHeight > window.innerHeight;
+
+        if (overflowsLeft && overflowsRight) {
+            submenu.style.top = '0px';
+            submenu.style.left = '0px';
+            return;
         }
 
-        const previousElementSiblingRect = submenu.previousElementSibling?.getBoundingClientRect();
-        if (previousElementSiblingRect && window.innerHeight < previousElementSiblingRect.top + submenu.offsetHeight) {
-            const heightDifference = window.innerHeight - previousElementSiblingRect.top - submenu.offsetHeight;
-            submenu.style.top = heightDifference + 'px';
-        } else {
-            submenu.style.top = '';
-        }
+        submenu.style.top = overflowsBottom ? `${window.innerHeight - triggerRect!.top - submenu.offsetHeight}px` : '';
     }
 }
 
@@ -94,6 +109,7 @@ const closeContextMenu = (e: any) => {
         contextMenuOpen.value = false;
     }
 };
+
 onMounted(() => {
     window.addEventListener('resize', closeContextMenu);
 });
@@ -107,17 +123,17 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
 <template>
     <Transition
         enter-active-class="ease-out duration-150"
-        enter-from-class="scale-[0.8] opacity-60"
+        enter-from-class="scale-80 opacity-0"
         enter-to-class="scale-100 opacity-100"
         leave-active-class="ease-in-out duration-100"
         leave-from-class="scale-100 opacity-100"
-        leave-to-class="scale-[0.1] opacity-50"
+        leave-to-class="scale-60 opacity-0"
     >
         <Teleport :to="teleportTarget" :disabled="teleportDisabled">
             <OnClickOutside
-                v-show="contextMenuOpen"
+                v-if="contextMenuOpen"
                 @trigger="
-                    (e: any) => {
+                    (e: MouseEvent) => {
                         contextMenuToggle(e, false);
                     }
                 "
@@ -127,7 +143,7 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
                         'absolute z-50 w-48 max-w-[100vw]',
                         'rounded-md border p-1 shadow-xs backdrop-blur-xs',
                         'bg-overlay-2-t border-overlay-border/10 pointer-events-auto',
-                        'text-xs transition-all',
+                        'origin-top-left text-xs transition-[opacity,scale]',
                         style,
                     )
                 "

--- a/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenu.vue
@@ -23,8 +23,8 @@ const { isOutside } = useMouseInElement(contextMenu);
 
 let lastEvent: MouseEvent | null = null;
 
-const contextMenuToggle = async (event: MouseEvent, override: boolean = true) => {
-    if (!override || props.disabled) {
+const contextMenuToggle = async (event?: MouseEvent, override: boolean = true) => {
+    if (!event || !override || props.disabled) {
         contextMenuOpen.value = false;
         return;
     }
@@ -73,7 +73,7 @@ async function calculateSubMenuPosition(event: MouseEvent) {
     const el = contextMenu.value?.$el as HTMLElement | undefined;
     if (!el) return;
 
-    const submenus = document.querySelectorAll<HTMLElement>('[data-submenu]');
+    const submenus = el.querySelectorAll<HTMLElement>('[data-submenu]');
     const menuRight = event.clientX + el.offsetWidth;
 
     for (const submenu of submenus) {
@@ -87,7 +87,6 @@ async function calculateSubMenuPosition(event: MouseEvent) {
         submenu.classList.toggle('-translate-x-full', overflowsRight && !overflowsLeft);
         submenu.classList.toggle('right-0', !overflowsRight);
         submenu.classList.toggle('translate-x-full', !overflowsRight);
-        submenu.classList.toggle('floating-menu', floating);
 
         const triggerRect = submenu.previousElementSibling?.getBoundingClientRect();
         const overflowsBottom = triggerRect && triggerRect.top + submenu.offsetHeight > window.innerHeight;
@@ -95,7 +94,7 @@ async function calculateSubMenuPosition(event: MouseEvent) {
         if (overflowsLeft && overflowsRight) {
             submenu.style.top = '0px';
             submenu.style.left = '0px';
-            return;
+            continue;
         }
 
         submenu.style.top = overflowsBottom ? `${window.innerHeight - triggerRect!.top - submenu.offsetHeight}px` : '';
@@ -103,11 +102,11 @@ async function calculateSubMenuPosition(event: MouseEvent) {
 }
 
 const closeContextMenu = (e: any) => {
-    if (contextMenuOpen.value && isOutside.value) {
-        e.preventDefault();
-        document.removeEventListener('contextmenu', closeContextMenu);
-        contextMenuOpen.value = false;
-    }
+    if (!contextMenuOpen.value || !isOutside.value) return;
+
+    e.preventDefault();
+    document.removeEventListener('contextmenu', closeContextMenu);
+    contextMenuOpen.value = false;
 };
 
 onMounted(() => {
@@ -132,11 +131,6 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
         <Teleport :to="teleportTarget" :disabled="teleportDisabled">
             <OnClickOutside
                 v-if="contextMenuOpen"
-                @trigger="
-                    (e: MouseEvent) => {
-                        contextMenuToggle(e, false);
-                    }
-                "
                 ref="contextMenu"
                 :class="
                     cn(
@@ -149,6 +143,7 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
                 "
                 :style="menuStyles"
                 v-cloak
+                @trigger="contextMenuToggle()"
             >
                 <slot name="content">
                     <ContextMenuItem
@@ -156,11 +151,7 @@ defineExpose({ contextMenuToggle, contextMenuOpen });
                         v-bind="item"
                         :key="index"
                         :class="itemStyle"
-                        @click="
-                            (e: any) => {
-                                contextMenuToggle(e, false);
-                            }
-                        "
+                        @click="contextMenuToggle()"
                     />
                 </slot>
             </OnClickOutside>

--- a/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
@@ -59,8 +59,8 @@ useMutationObserver(subMenu, () => (isFloating.value = subMenu.value?.dataset.fl
                     {
                         'bg-overlay-2-t border-overlay-border/10 absolute top-0 max-h-none w-48 rounded-md border p-1 shadow-xs backdrop-blur-xs duration-100': isFloating,
                         'scrollbar-minimal -mx-1 flex flex-col gap-1 overflow-y-auto transition-[opacity,max-height]': !isFloating,
-                        'max-h-0 group-focus-within/submenu:max-h-32 group-hover/submenu:max-h-32': !isFloating && !isSubMenuOpen,
-                        'pointer-events-auto max-h-32 opacity-100': !isFloating && isSubMenuOpen,
+                        'max-h-0 group-focus-within/submenu:max-h-33 group-hover/submenu:max-h-33': !isFloating && !isSubMenuOpen,
+                        'pointer-events-auto max-h-33 opacity-100': !isFloating && isSubMenuOpen,
                     },
                     submenuStyle,
                 )

--- a/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
@@ -35,7 +35,17 @@ useMutationObserver(subMenu, () => (isFloating.value = subMenu.value?.dataset.fl
             v-bind="wrapperProps"
             :class="cn({ [selectedStyle]: selected }, 'hocus:bg-overlay-accent h-7 w-full justify-start rounded-sm px-2 py-1.5 select-none focus:outline-none', style)"
             :disabled="disabled"
-            @click.stop="hasChildren ? (isSubMenuOpen = !isSubMenuOpen) : action?.()"
+            @click="
+                (e: MouseEvent) => {
+                    if (hasChildren) {
+                        e.stopPropagation();
+                        isSubMenuOpen = !isSubMenuOpen;
+                        return;
+                    }
+
+                    action?.();
+                }
+            "
         >
             <slot name="icon">
                 <component v-if="icon" :is="icon" class="size-4 shrink-0" />

--- a/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
@@ -67,7 +67,8 @@ useMutationObserver(subMenu, () => (isFloating.value = subMenu.value?.dataset.fl
                     'pointer-events-none group-focus-within/submenu:pointer-events-auto group-hover/submenu:pointer-events-auto',
                     'transition-opacity duration-300 ease-in group-hover/submenu:ease-out',
                     {
-                        'bg-overlay-2-t border-overlay-border/10 absolute top-0 max-h-none w-48 rounded-md border p-1 shadow-xs backdrop-blur-xs duration-100': isFloating,
+                        'bg-overlay-2-t border-overlay-border/10 dark:border-overlay-border/20 absolute top-0 max-h-none w-48 rounded-md border p-1 shadow-xs backdrop-blur-xs duration-100':
+                            isFloating,
                         'scrollbar-minimal -mx-1 flex flex-col gap-1 overflow-y-auto transition-[opacity,max-height]': !isFloating,
                         'max-h-0 group-focus-within/submenu:max-h-33 group-hover/submenu:max-h-33': !isFloating && !isSubMenuOpen,
                         'pointer-events-auto max-h-33 opacity-100': !isFloating && isSubMenuOpen,
@@ -76,7 +77,7 @@ useMutationObserver(subMenu, () => (isFloating.value = subMenu.value?.dataset.fl
                 )
             "
         >
-            <div :class="cn('bg-hr dark:bg-hr/30 top-0 h-0', { 'sticky min-h-px': !isFloating })" />
+            <div :class="cn('bg-hr dark:bg-hr/30 top-0 h-0', { 'sticky z-3 min-h-px': !isFloating })" />
             <ContextMenuItem v-for="(child, index) in children" :key="index" v-bind="child" :class="cn({ 'ps-2 pe-1': !isFloating })" />
         </div>
     </div>

--- a/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { ContextMenuItem } from '@aminnausin/cedar-ui';
 
+import { computed, ref, useTemplateRef } from 'vue';
+import { useMutationObserver } from '@vueuse/core';
 import { ButtonBase } from '@/components/cedar-ui/button';
-import { computed } from 'vue';
 import { cn } from '@aminnausin/cedar-ui';
 
 import ProiconsChevronRight from '~icons/proicons/chevron-right';
@@ -11,13 +12,20 @@ const props = withDefaults(defineProps<ContextMenuItem & { divider?: boolean; ch
     selectedStyle: 'text-primary font-bold',
 });
 
+const isSubMenuOpen = ref(false);
+const isFloating = ref(true);
+
+const subMenu = useTemplateRef('sub-menu');
+
+const hasChildren = computed(() => (props.children?.length ?? 0) > 0);
+
 const wrapperProps = computed(() => {
     if (!props.url) return {};
     if (props.external) return { href: props.url, target: props.target ?? '_blank' };
     return { to: props.url, target: props.target };
 });
 
-const hasChildren = computed(() => (props.children?.length ?? 0) > 0);
+useMutationObserver(subMenu, () => (isFloating.value = subMenu.value?.dataset.floating !== 'false'), { attributeFilter: ['data-floating'] });
 </script>
 <template>
     <div v-if="divider" class="bg-hr dark:bg-hr/30 -mx-1 my-1 h-px" />
@@ -25,9 +33,9 @@ const hasChildren = computed(() => (props.children?.length ?? 0) > 0);
     <div v-else class="relative" :class="{ 'group/submenu': hasChildren }">
         <ButtonBase
             v-bind="wrapperProps"
-            :class="cn({ [selectedStyle]: selected }, 'hocus:bg-overlay-accent h-7 w-full justify-start rounded-sm px-2 py-1.5 select-none', style)"
+            :class="cn({ [selectedStyle]: selected }, 'hocus:bg-overlay-accent h-7 w-full justify-start rounded-sm px-2 py-1.5 select-none focus:outline-none', style)"
             :disabled="disabled"
-            @click.stop="if (!hasChildren) action?.();"
+            @click.stop="hasChildren ? (isSubMenuOpen = !isSubMenuOpen) : action?.()"
         >
             <slot name="icon">
                 <component v-if="icon" :is="icon" class="size-4 shrink-0" />
@@ -40,30 +48,26 @@ const hasChildren = computed(() => (props.children?.length ?? 0) > 0);
 
         <div
             v-if="hasChildren"
+            ref="sub-menu"
             data-submenu
             data-floating="true"
             :class="
                 cn(
-                    'floating-menu peer max-h-0 px-2',
-                    'opacity-0',
-                    'group-hover/submenu:max-h-none group-hover/submenu:opacity-100',
-                    'group-focus-within/submenu:pointer-events-auto group-focus-within/submenu:opacity-100',
+                    'opacity-0 group-focus-within/submenu:opacity-100 group-hover/submenu:opacity-100',
+                    'pointer-events-none group-focus-within/submenu:pointer-events-auto group-hover/submenu:pointer-events-auto',
+                    'transition-opacity duration-300 ease-in group-hover/submenu:ease-out',
+                    {
+                        'bg-overlay-2-t border-overlay-border/10 absolute top-0 max-h-none w-48 rounded-md border p-1 shadow-xs backdrop-blur-xs duration-100': isFloating,
+                        'scrollbar-minimal -mx-1 flex flex-col gap-1 overflow-y-auto transition-[opacity,max-height]': !isFloating,
+                        'max-h-0 group-focus-within/submenu:max-h-32 group-hover/submenu:max-h-32': !isFloating && !isSubMenuOpen,
+                        'pointer-events-auto max-h-32 opacity-100': !isFloating && isSubMenuOpen,
+                    },
                     submenuStyle,
                 )
             "
         >
-            <div class="submenu-divider bg-hr dark:bg-hr/30 -mx-3 my-1 h-px" />
-            <ContextMenuItem v-for="(child, index) in children" :key="index" v-bind="child" />
+            <div :class="cn('bg-hr dark:bg-hr/30 top-0 h-0', { 'sticky min-h-px': !isFloating })" />
+            <ContextMenuItem v-for="(child, index) in children" :key="index" v-bind="child" :class="cn({ 'ps-2 pe-1': !isFloating })" />
         </div>
     </div>
 </template>
-<style lang="css" scoped>
-@reference '@css/app.css';
-.floating-menu {
-    @apply bg-overlay-2-t border-overlay-border/10 absolute top-0 max-h-none w-48 rounded-md border p-1 px-1! shadow-xs backdrop-blur-xs transition-opacity duration-100 ease-in group-hover/submenu:ease-out;
-}
-
-[data-submenu][data-floating='true'] > .submenu-divider {
-    display: none;
-}
-</style>

--- a/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
+++ b/resources/js/components/cedar-ui/context-menu/ContextMenuItem.vue
@@ -5,7 +5,9 @@ import { ButtonBase } from '@/components/cedar-ui/button';
 import { computed } from 'vue';
 import { cn } from '@aminnausin/cedar-ui';
 
-const props = withDefaults(defineProps<ContextMenuItem & { divider?: boolean }>(), {
+import ProiconsChevronRight from '~icons/proicons/chevron-right';
+
+const props = withDefaults(defineProps<ContextMenuItem & { divider?: boolean; children?: ContextMenuItem[]; submenuStyle?: string }>(), {
     selectedStyle: 'text-primary font-bold',
 });
 
@@ -14,26 +16,54 @@ const wrapperProps = computed(() => {
     if (props.external) return { href: props.url, target: props.target ?? '_blank' };
     return { to: props.url, target: props.target };
 });
+
+const hasChildren = computed(() => (props.children?.length ?? 0) > 0);
 </script>
 <template>
     <div v-if="divider" class="bg-hr dark:bg-hr/30 -mx-1 my-1 h-px" />
 
-    <ButtonBase
-        v-else
-        v-bind="wrapperProps"
-        :class="cn({ [selectedStyle]: selected }, 'hover:bg-overlay-accent h-7 w-full justify-start rounded-sm px-2 py-1.5 select-none', style)"
-        :disabled="disabled"
-        :onclick="
-            () => {
-                if (action) action();
-            }
-        "
-    >
-        <slot name="icon">
-            <component v-if="icon" :is="icon" class="size-4 shrink-0" />
-            <span v-else class="size-4 shrink-0"> </span>
-        </slot>
-        <span class="mr-auto truncate text-nowrap">{{ text }}</span>
-        <span class="tracking-widest opacity-60" v-if="shortcut">{{ shortcut }}</span>
-    </ButtonBase>
+    <div v-else class="relative" :class="{ 'group/submenu': hasChildren }">
+        <ButtonBase
+            v-bind="wrapperProps"
+            :class="cn({ [selectedStyle]: selected }, 'hocus:bg-overlay-accent h-7 w-full justify-start rounded-sm px-2 py-1.5 select-none', style)"
+            :disabled="disabled"
+            @click.stop="if (!hasChildren) action?.();"
+        >
+            <slot name="icon">
+                <component v-if="icon" :is="icon" class="size-4 shrink-0" />
+                <span v-else class="size-4 shrink-0" />
+            </slot>
+            <span class="mr-auto truncate text-nowrap">{{ text }}</span>
+            <ProiconsChevronRight v-if="hasChildren" class="size-3 opacity-60" />
+            <span v-else-if="shortcut" class="tracking-widest opacity-60">{{ shortcut }}</span>
+        </ButtonBase>
+
+        <div
+            v-if="hasChildren"
+            data-submenu
+            data-floating="true"
+            :class="
+                cn(
+                    'floating-menu peer max-h-0 px-2',
+                    'opacity-0',
+                    'group-hover/submenu:max-h-none group-hover/submenu:opacity-100',
+                    'group-focus-within/submenu:pointer-events-auto group-focus-within/submenu:opacity-100',
+                    submenuStyle,
+                )
+            "
+        >
+            <div class="submenu-divider bg-hr dark:bg-hr/30 -mx-3 my-1 h-px" />
+            <ContextMenuItem v-for="(child, index) in children" :key="index" v-bind="child" />
+        </div>
+    </div>
 </template>
+<style lang="css" scoped>
+@reference '@css/app.css';
+.floating-menu {
+    @apply bg-overlay-2-t border-overlay-border/10 absolute top-0 max-h-none w-48 rounded-md border p-1 px-1! shadow-xs backdrop-blur-xs transition-opacity duration-100 ease-in group-hover/submenu:ease-out;
+}
+
+[data-submenu][data-floating='true'] > .submenu-divider {
+    display: none;
+}
+</style>

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -821,6 +821,8 @@ const handleFullScreen = async () => {
         toast.error('Unable to switch fullscreen mode...');
         console.log(error);
     }
+
+    if (playerContextMenu.value?.contextMenuOpen) playerContextMenu.value?.contextMenuToggle();
 };
 
 const handleFullScreenChange = (e: Event) => {
@@ -1329,8 +1331,8 @@ defineExpose({
         @mouseleave="handleControlsTimeout"
         @contextmenu="
             (e: any) => {
-                setContextMenu(e, { items: playerContextMenuItems });
-                playerContextMenu?.contextMenuToggle(e, true);
+                if (isNormalView) setContextMenu(e, { items: playerContextMenuItems });
+                else playerContextMenu?.contextMenuToggle(e, true);
             }
         "
     >

--- a/resources/js/components/video/VideoPlayer.vue
+++ b/resources/js/components/video/VideoPlayer.vue
@@ -270,68 +270,65 @@ const progressTooltip = computed(() => timeline.value?.progressTooltip);
 
 // const url = ref('');
 
-const playerContextMenuItems = computed(() => {
-    const items: ContextMenuItem[] = [
-        {
-            text: 'Loop',
-            icon: isLooping.value ? ProiconsCheckmark : undefined,
-            action: () => {
-                isLooping.value = !isLooping.value;
-            },
+const playerContextMenuItems = computed<ContextMenuItem[]>(() => [
+    {
+        text: 'Loop',
+        icon: isLooping.value ? ProiconsCheckmark : undefined,
+        action: () => {
+            isLooping.value = !isLooping.value;
         },
-        {
-            text: 'Player Stats',
-            icon: isShowingStats.value ? ProiconsCheckmark : undefined,
-            action: () => {
-                isShowingStats.value = !isShowingStats.value;
-            },
+    },
+    {
+        text: 'Player Stats',
+        icon: isShowingStats.value ? ProiconsCheckmark : undefined,
+        action: () => {
+            isShowingStats.value = !isShowingStats.value;
         },
-        {
-            text: 'Watch Party',
-            icon: isShowingParty.value ? ProiconsCheckmark : undefined,
-            selected: isShowingParty.value,
-            disabled: !userData.value?.id,
-            action: () => {
-                isShowingParty.value = !isShowingParty.value;
-            },
+    },
+    {
+        text: 'Watch Party',
+        icon: isShowingParty.value ? ProiconsCheckmark : undefined,
+        selected: isShowingParty.value,
+        disabled: !userData.value?.id,
+        action: () => {
+            isShowingParty.value = !isShowingParty.value;
         },
-        {
-            text: 'Show Miniplayer',
-            icon: isPictureInPicture.value ? ProiconsCheckmark : undefined,
-            hidden: !document.pictureInPictureEnabled || isAudio.value,
-            action: () => {
-                if (isLoading.value) return;
-                togglePictureInPicture();
-            },
+    },
+    {
+        text: 'Show Miniplayer',
+        icon: isPictureInPicture.value ? ProiconsCheckmark : undefined,
+        hidden: !document.pictureInPictureEnabled || isAudio.value,
+        action: () => {
+            if (isLoading.value) return;
+            togglePictureInPicture();
         },
-        {
-            text: 'Audio Graph Menu',
-            icon: isShowingAudioGraphSettings.value ? ProiconsCheckmark : undefined,
-            selected: isShowingAudioGraphSettings.value,
-            hidden: !isAudioGraphEnabled.value,
-            action: () => {
-                isShowingAudioGraphSettings.value = !isShowingAudioGraphSettings.value;
-            },
+    },
+    {
+        text: 'Audio Graph Menu',
+        icon: isShowingAudioGraphSettings.value ? ProiconsCheckmark : undefined,
+        selected: isShowingAudioGraphSettings.value,
+        hidden: !isAudioGraphEnabled.value,
+        action: () => {
+            isShowingAudioGraphSettings.value = !isShowingAudioGraphSettings.value;
         },
-        {
-            text: 'Save Frame',
-            hidden: isAudio.value,
-            action: () => {
-                if (!player.value) return;
-                saveVideoFrame(player.value);
-            },
+    },
+    {
+        text: 'Save Frame',
+        hidden: isAudio.value,
+        action: () => {
+            if (!player.value) return;
+            saveVideoFrame(player.value);
         },
-        {
-            text: 'Copy Frame',
-            hidden: isAudio.value,
-            action: () => {
-                if (!player.value) return;
-                copyVideoFrame(player.value);
-            },
+    },
+    {
+        text: 'Copy Frame',
+        hidden: isAudio.value,
+        action: () => {
+            if (!player.value) return;
+            copyVideoFrame(player.value);
         },
-    ];
-    return items;
-});
+    },
+]);
 
 const videoPopoverItems = computed(() => {
     const items: PopoverItem[] = [
@@ -729,7 +726,7 @@ const handleSpeedWheel = (event: WheelEvent) => {
     if (!player.value) return;
     event.preventDefault();
 
-    if (!handleSpeedChange(new Event('SpeedChange'), event.deltaY < 0 ? 1 : -1)) return;
+    handleSpeedChange(new Event('SpeedChange'), event.deltaY < 0 ? 1 : -1);
 };
 
 const handleMute = () => {

--- a/resources/js/components/video/VideoPreview.vue
+++ b/resources/js/components/video/VideoPreview.vue
@@ -239,7 +239,7 @@ defineExpose({ hovered });
             </div>
         </template>
 
-        <div v-else :class="cn('bg-surface-3 flex aspect-video h-24 shrink-0 items-center justify-center dark:bg-neutral-900/80', { 'w-24': isFolderMajorityAudio })">
+        <div v-else :class="cn('bg-surface-3 flex aspect-video h-24 shrink-0 items-center justify-center dark:bg-neutral-900/80', { 'w-24': isFolderMajorityAudio }, $attrs.class)">
             <ProIconsPhotoOff class="text-foreground-1 size-5" />
         </div>
     </div>

--- a/resources/js/types/types.ts
+++ b/resources/js/types/types.ts
@@ -63,6 +63,8 @@ export interface ContextMenuItem {
     hidden?: boolean;
     icon?: Component;
     divider?: boolean;
+    children?: ContextMenuItem[];
+    submenuStye?: string;
 }
 
 export interface ContextMenu {


### PR DESCRIPTION
### Fixes

- Context menu animation is choppy on mobile
- The context menu does not follow traditional ux standards
  - It animates position everytime a new contextmenu is opened instead of closing and opening again

### Additions

- Enabled submenus in context menu (skeleton code was already present)

### Demo

- Submenus

<img width="280"  alt="output3" src="https://github.com/user-attachments/assets/a1e1ded7-e941-468d-af03-3cf915d95db6" />

- Context menu animation

| Old | New |
|----|----|
|<img width="360"  alt="cmOld" src="https://github.com/user-attachments/assets/7c6fc834-f887-4a0f-bd1f-c1b39e4c023a" />|<img width="360" alt="cmNew" src="https://github.com/user-attachments/assets/0a74ab51-105d-41a6-b859-dea17d79313d" />|