### PR TITLE
Fix/qsv storyboard

### DIFF
--- a/app/Services/Ffmpeg/FFmpegCommandBuilder.php
+++ b/app/Services/Ffmpeg/FFmpegCommandBuilder.php
@@ -9,7 +9,8 @@ use App\Services\Images\Storyboard\StoryboardOptions;
 class FFmpegCommandBuilder {
     public function __construct(
         private HardwareDetectionService $hardware,
-    ) {}
+    ) {
+    }
 
     public function storyboard(string $filePath, string $outputPattern, StoryboardOptions $options): array {
         $profile = $this->hardware->detect();
@@ -61,7 +62,7 @@ class FFmpegCommandBuilder {
         };
 
         $scale = match ($hw) {
-            HardwareType::QSV => "hwmap=derive_device=qsv,vpp_qsv=w={$w}:h={$h}:format=nv12:out_range=pc:scale_mode=hq",
+            HardwareType::QSV => "hwmap=derive_device=qsv,vpp_qsv=w={$w}:h={$h}:format=nv12:out_range=pc:scale_mode=hq,hwdownload,format=nv12",
             default => "scale='min({$w},iw)':-2:flags=lanczos",
         };
 

--- a/app/Services/Ffmpeg/FFmpegCommandBuilder.php
+++ b/app/Services/Ffmpeg/FFmpegCommandBuilder.php
@@ -61,7 +61,7 @@ class FFmpegCommandBuilder {
         };
 
         $scale = match ($hw) {
-            HardwareType::QSV => "hwmap=derive_device=qsv,vpp_qsv=w={$w}:h={$h}:format=nv12:passthrough=0:out_range=pc:scale_mode=hq",
+            HardwareType::QSV => "hwmap=derive_device=qsv,vpp_qsv=w={$w}:h={$h}:format=nv12:out_range=pc:scale_mode=hq",
             default => "scale='min({$w},iw)':-2:flags=lanczos",
         };
 

--- a/app/Services/Ffmpeg/FFmpegCommandBuilder.php
+++ b/app/Services/Ffmpeg/FFmpegCommandBuilder.php
@@ -40,7 +40,7 @@ class FFmpegCommandBuilder {
         $h = $options->height;
 
         $scale = match ($hw) {
-            HardwareType::QSV => "vpp_qsv=w={$w}:h={$h}:format=nv12:passthrough=0:out_range=pc:scale_mode=hq",
+            HardwareType::QSV => "vpp_qsv=w={$w}:h={$h}:format=nv12:out_range=pc:scale_mode=hq",
             default => "scale='min({$w},iw)':-2:flags=lanczos",
         };
 

--- a/app/Services/Ffmpeg/FFmpegCommandBuilder.php
+++ b/app/Services/Ffmpeg/FFmpegCommandBuilder.php
@@ -12,35 +12,56 @@ class FFmpegCommandBuilder {
     ) {}
 
     public function storyboard(string $filePath, string $outputPattern, StoryboardOptions $options): array {
-        $hw = $this->hardware->detect()->best();
+        $profile = $this->hardware->detect();
+        $hw = $profile->best();
 
-        $defaultEncode = [
-            'mjpeg',
-        ];
+        $defaultEncode = ['mjpeg'];
+        $w = $options->width;
+        $h = $options->height;
 
-        $hardwareOptions = match ($hw) {
-            HardwareType::CUDA => [
+        $hardwareOptions = match (true) {
+            $hw === HardwareType::CUDA => [
+                'init' => [],
                 'decode' => ['-hwaccel', 'cuda'],
                 'decode_flags' => ['-noautoscale'],
                 'encode' => $defaultEncode,
             ],
-            HardwareType::QSV => [
-                'decode' => [],
-                'decode_flags' => ['-noautoscale'],
+            $hw === HardwareType::QSV && $profile->qsv === 'derive_vaapi' && $profile->vaapiDevice => [
+                'init' => [
+                    '-init_hw_device',
+                    "vaapi=va:{$profile->vaapiDevice}",
+                    '-init_hw_device',
+                    'qsv=qs@va',
+                    '-filter_hw_device',
+                    'qs',
+                ],
+                'decode' => ['-hwaccel', 'vaapi', '-hwaccel_output_format', 'vaapi'],
+                'decode_flags' => [],
+                'encode' => ['mjpeg_qsv'],
+            ],
+            $hw === HardwareType::QSV && $profile->qsv === 'derive_d3d11va' => [
+                'init' => [
+                    '-init_hw_device',
+                    'd3d11va=dx11:,vendor=' . HardwareDetectionService::INTEL_VENDOR_ID,
+                    '-init_hw_device',
+                    'qsv=qs@dx11',
+                    '-filter_hw_device',
+                    'qs',
+                ],
+                'decode' => ['-hwaccel', 'd3d11va', '-hwaccel_output_format', 'd3d11'],
+                'decode_flags' => [],
                 'encode' => ['mjpeg_qsv'],
             ],
             default => [
+                'init' => [],
                 'decode' => [],
                 'decode_flags' => [],
                 'encode' => $defaultEncode,
             ],
         };
 
-        $w = $options->width;
-        $h = $options->height;
-
         $scale = match ($hw) {
-            HardwareType::QSV => "vpp_qsv=w={$w}:h={$h}:format=nv12:out_range=pc:scale_mode=hq",
+            HardwareType::QSV => "hwmap=derive_device=qsv,vpp_qsv=w={$w}:h={$h}:format=nv12:passthrough=0:out_range=pc:scale_mode=hq",
             default => "scale='min({$w},iw)':-2:flags=lanczos",
         };
 
@@ -59,6 +80,7 @@ class FFmpegCommandBuilder {
 
         return [
             'ffmpeg',
+            ...$hardwareOptions['init'],
             ...$hardwareOptions['decode'],
             ...$skipFrame,
             '-threads',
@@ -68,7 +90,7 @@ class FFmpegCommandBuilder {
             '-an',
             '-sn',
             '-vf',
-            "fps={$options->fps},{$scale},setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,tile={$options->cols}x{$options->rows}",
+            "fps={$options->fps},setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,{$scale},tile={$options->cols}x{$options->rows}",
             '-threads',
             '1',
             '-c:v',

--- a/app/Services/Ffmpeg/FFmpegCommandBuilder.php
+++ b/app/Services/Ffmpeg/FFmpegCommandBuilder.php
@@ -9,8 +9,7 @@ use App\Services\Images\Storyboard\StoryboardOptions;
 class FFmpegCommandBuilder {
     public function __construct(
         private HardwareDetectionService $hardware,
-    ) {
-    }
+    ) {}
 
     public function storyboard(string $filePath, string $outputPattern, StoryboardOptions $options): array {
         $profile = $this->hardware->detect();

--- a/app/Services/Hardware/HardwareDetectionService.php
+++ b/app/Services/Hardware/HardwareDetectionService.php
@@ -8,6 +8,12 @@ use Symfony\Component\Process\Process;
 class HardwareDetectionService {
     private ?HardwareProfile $cached = null;
 
+    const PROFILE_VERSION = 2;
+
+    const CACHE_KEY = 'ffmpeg_hardware_profile_v' . self::PROFILE_VERSION;
+
+    const INTEL_VENDOR_ID = '0x8086';
+
     const DEFAULT_ARGUMENTS = [
         '-hide_banner',
         '-loglevel',
@@ -19,25 +25,28 @@ class HardwareDetectionService {
             return $this->cached;
         }
 
-        $cached = Cache::remember('ffmpeg_hardware_profile', 86400, function () {
+        $profile = Cache::remember(self::CACHE_KEY, 86400, function () {
             $hwaccels = $this->getHwaccels();
             $encoders = $this->getEncoders();
+            $vaapiDevice = $this->findIntelRenderDevice();
 
             return [
                 'cuda' => in_array('cuda', $hwaccels) && $this->validateCuda(),
-                'qsv' => in_array('qsv', $hwaccels) && in_array('mjpeg_qsv', $encoders) && $this->validateQsv(),
+                'qsv' => in_array('qsv', $hwaccels) && in_array('mjpeg_qsv', $encoders) ? $this->validateQsv($vaapiDevice) : null,
                 'vaapi' => in_array('vaapi', $hwaccels) && $this->validateVaapi(),
+                'vaapi_device' => $vaapiDevice,
             ];
         });
 
         return $this->cached = new HardwareProfile(
-            cuda: $cached['cuda'],
-            qsv: $cached['qsv'],
-            vaapi: $cached['vaapi'],
+            cuda: $profile['cuda'],
+            qsv: $profile['qsv'],
+            vaapi: $profile['vaapi'],
+            vaapiDevice: $profile['vaapi_device']
         );
     }
 
-    public function getHwaccels(): array {
+    private function getHwaccels(): array {
         $process = new Process(['ffmpeg', '-hwaccels', ...self::DEFAULT_ARGUMENTS]);
         $process->run();
         $output = $process->getOutput();
@@ -47,7 +56,7 @@ class HardwareDetectionService {
         return array_values(array_filter(array_map('trim', $lines)));
     }
 
-    public function getEncoders(): array {
+    private function getEncoders(): array {
         $process = new Process(['ffmpeg', '-encoders', '-hide_banner']);
         $process->run();
         preg_match_all('/\s(\w+)\s/', $process->getOutput(), $matches);
@@ -55,7 +64,7 @@ class HardwareDetectionService {
         return $matches[1] ?? [];
     }
 
-    public function validateCuda(): bool {
+    private function validateCuda(): bool {
         $process = new Process([
             'ffmpeg',
             ...self::DEFAULT_ARGUMENTS,
@@ -78,7 +87,7 @@ class HardwareDetectionService {
         return $process->isSuccessful();
     }
 
-    public function validateVaapi(): bool {
+    private function validateVaapi(): bool {
         $process = new Process([
             'ffmpeg',
             ...self::DEFAULT_ARGUMENTS,
@@ -101,7 +110,96 @@ class HardwareDetectionService {
         return $process->isSuccessful();
     }
 
-    private function validateQsv(): bool {
+    private function validateQsv(?string $vaapiDevice): ?string {
+        return match (PHP_OS_FAMILY) {
+            'Windows' => $this->validateQsvD3d11va() ? 'derive_d3d11va' : null,
+            'Linux' => $this->validateQsvVaapi($vaapiDevice) ? 'derive_vaapi' : null,
+            default => null
+        };
+    }
+
+    /**
+     * Linux QSV detection using vaapi and a specific device path
+     */
+    private function validateQsvVaapi(string $devicePath): bool {
+        if (! $devicePath) {
+            return false;
+        }
+        $process = new Process([
+            'ffmpeg',
+            ...self::DEFAULT_ARGUMENTS,
+            '-init_hw_device',
+            "vaapi=va:{$devicePath}",
+            '-init_hw_device',
+            'qsv=qs@va',
+            '-filter_hw_device',
+            'qs',
+            '-f',
+            'lavfi',
+            '-i',
+            'nullsrc=s=16x16',
+            '-frames:v',
+            '1',
+            '-f',
+            'null',
+            '-',
+        ]);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    /**
+     * Windows QSV detection using D3D11VA and the Intel vendor ID
+     */
+    private function validateQsvD3d11va(): bool {
+        $process = new Process([
+            'ffmpeg',
+            ...self::DEFAULT_ARGUMENTS,
+            '-init_hw_device',
+            'd3d11va=dx11:,vendor=' . self::INTEL_VENDOR_ID,
+            '-init_hw_device',
+            'qsv=qs@dx11',
+            '-filter_hw_device',
+            'qs',
+            '-f',
+            'lavfi',
+            '-i',
+            'nullsrc=s=16x16',
+            '-frames:v',
+            '1',
+            '-f',
+            'null',
+            '-',
+        ]);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    /**
+     * Searches for a render node with the Intel vendor ID
+     */
+    private function findIntelRenderDevice(): ?string {
+        $renderNodes = glob('/dev/dri/renderD*') ?: [];
+
+        foreach ($renderNodes as $node) {
+            $name = basename($node);
+            $vendorPath = "/sys/class/drm/{$name}/device/vendor";
+
+            if (is_readable($vendorPath) && trim(file_get_contents($vendorPath)) === self::INTEL_VENDOR_ID) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Old way of deriving basic qsv without vaapi or D3d11va
+     * This method was often slower than just using the CPU
+     */
+    private function validateQsvPlain(): bool {
         $process = new Process([
             'ffmpeg',
             ...self::DEFAULT_ARGUMENTS,

--- a/app/Services/Hardware/HardwareDetectionService.php
+++ b/app/Services/Hardware/HardwareDetectionService.php
@@ -20,6 +20,18 @@ class HardwareDetectionService {
         'error',
     ];
 
+    const VALIDATION_ARGUMENTS = [
+        '-f',
+        'lavfi',
+        '-i',
+        'nullsrc=s=16x16',
+        '-frames:v',
+        '1',
+        '-f',
+        'null',
+        '-',
+    ];
+
     public function detect(): HardwareProfile {
         if ($this->cached) {
             return $this->cached;
@@ -72,15 +84,7 @@ class HardwareDetectionService {
             'cuda',
             '-hwaccel_output_format',
             'cuda',
-            '-f',
-            'lavfi',
-            '-i',
-            'nullsrc=s=16x16',
-            '-frames:v',
-            '1',
-            '-f',
-            'null',
-            '-',
+            ...self::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -95,15 +99,7 @@ class HardwareDetectionService {
             'vaapi',
             '-hwaccel_device',
             '/dev/dri/renderD128',
-            '-f',
-            'lavfi',
-            '-i',
-            'nullsrc=s=16x16',
-            '-frames:v',
-            '1',
-            '-f',
-            'null',
-            '-',
+            ...self::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -134,15 +130,7 @@ class HardwareDetectionService {
             'qsv=qs@va',
             '-filter_hw_device',
             'qs',
-            '-f',
-            'lavfi',
-            '-i',
-            'nullsrc=s=16x16',
-            '-frames:v',
-            '1',
-            '-f',
-            'null',
-            '-',
+            ...self::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -163,15 +151,7 @@ class HardwareDetectionService {
             'qsv=qs@dx11',
             '-filter_hw_device',
             'qs',
-            '-f',
-            'lavfi',
-            '-i',
-            'nullsrc=s=16x16',
-            '-frames:v',
-            '1',
-            '-f',
-            'null',
-            '-',
+            ...self::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -208,15 +188,7 @@ class HardwareDetectionService {
             ...self::DEFAULT_ARGUMENTS,
             '-hwaccel',
             'qsv',
-            '-f',
-            'lavfi',
-            '-i',
-            'color=c=black:s=16x16:r=1',
-            '-frames:v',
-            '1',
-            '-f',
-            'null',
-            '-',
+            ...self::VALIDATION_ARGUMENTS,
         ]);
         $process->setTimeout(10);
         $process->run();

--- a/app/Services/Hardware/HardwareDetectionService.php
+++ b/app/Services/Hardware/HardwareDetectionService.php
@@ -151,6 +151,7 @@ class HardwareDetectionService {
 
     /**
      * Windows QSV detection using D3D11VA and the Intel vendor ID
+     * Doesn't really work because `qsv=qs@dx11` fails on the native ffmpeg binary, might be a jellyfin specific thing
      */
     private function validateQsvD3d11va(): bool {
         $process = new Process([
@@ -198,6 +199,8 @@ class HardwareDetectionService {
     /**
      * Old way of deriving basic qsv without vaapi or D3d11va
      * This method was often slower than just using the CPU
+     *
+     * For reference only
      */
     private function validateQsvPlain(): bool {
         $process = new Process([

--- a/app/Services/Hardware/HardwareDetectionService.php
+++ b/app/Services/Hardware/HardwareDetectionService.php
@@ -8,9 +8,7 @@ use Symfony\Component\Process\Process;
 class HardwareDetectionService {
     private ?HardwareProfile $cached = null;
 
-    const PROFILE_VERSION = 2;
-
-    const CACHE_KEY = 'ffmpeg_hardware_profile_v' . self::PROFILE_VERSION;
+    const CACHE_KEY = 'ffmpeg_hardware_profile_v' . HardwareProfile::PROFILE_VERSION;
 
     const INTEL_VENDOR_ID = '0x8086';
 
@@ -37,7 +35,7 @@ class HardwareDetectionService {
             return $this->cached;
         }
 
-        $profile = Cache::remember(self::CACHE_KEY, 86400, function () {
+        $profile = Cache::remember(HardwareDetectionService::CACHE_KEY, 86400, function () {
             $hwaccels = $this->getHwaccels();
             $encoders = $this->getEncoders();
             $vaapiDevice = $this->findIntelRenderDevice();
@@ -59,7 +57,7 @@ class HardwareDetectionService {
     }
 
     private function getHwaccels(): array {
-        $process = new Process(['ffmpeg', '-hwaccels', ...self::DEFAULT_ARGUMENTS]);
+        $process = new Process(['ffmpeg', '-hwaccels', ...HardwareDetectionService::DEFAULT_ARGUMENTS]);
         $process->run();
         $output = $process->getOutput();
 
@@ -79,12 +77,12 @@ class HardwareDetectionService {
     private function validateCuda(): bool {
         $process = new Process([
             'ffmpeg',
-            ...self::DEFAULT_ARGUMENTS,
+            ...HardwareDetectionService::DEFAULT_ARGUMENTS,
             '-hwaccel',
             'cuda',
             '-hwaccel_output_format',
             'cuda',
-            ...self::VALIDATION_ARGUMENTS,
+            ...HardwareDetectionService::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -94,12 +92,12 @@ class HardwareDetectionService {
     private function validateVaapi(): bool {
         $process = new Process([
             'ffmpeg',
-            ...self::DEFAULT_ARGUMENTS,
+            ...HardwareDetectionService::DEFAULT_ARGUMENTS,
             '-hwaccel',
             'vaapi',
             '-hwaccel_device',
             '/dev/dri/renderD128',
-            ...self::VALIDATION_ARGUMENTS,
+            ...HardwareDetectionService::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -123,14 +121,14 @@ class HardwareDetectionService {
         }
         $process = new Process([
             'ffmpeg',
-            ...self::DEFAULT_ARGUMENTS,
+            ...HardwareDetectionService::DEFAULT_ARGUMENTS,
             '-init_hw_device',
             "vaapi=va:{$devicePath}",
             '-init_hw_device',
             'qsv=qs@va',
             '-filter_hw_device',
             'qs',
-            ...self::VALIDATION_ARGUMENTS,
+            ...HardwareDetectionService::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -144,14 +142,14 @@ class HardwareDetectionService {
     private function validateQsvD3d11va(): bool {
         $process = new Process([
             'ffmpeg',
-            ...self::DEFAULT_ARGUMENTS,
+            ...HardwareDetectionService::DEFAULT_ARGUMENTS,
             '-init_hw_device',
-            'd3d11va=dx11:,vendor=' . self::INTEL_VENDOR_ID,
+            'd3d11va=dx11:,vendor=' . HardwareDetectionService::INTEL_VENDOR_ID,
             '-init_hw_device',
             'qsv=qs@dx11',
             '-filter_hw_device',
             'qs',
-            ...self::VALIDATION_ARGUMENTS,
+            ...HardwareDetectionService::VALIDATION_ARGUMENTS,
         ]);
         $process->run();
 
@@ -168,7 +166,7 @@ class HardwareDetectionService {
             $name = basename($node);
             $vendorPath = "/sys/class/drm/{$name}/device/vendor";
 
-            if (is_readable($vendorPath) && trim(file_get_contents($vendorPath)) === self::INTEL_VENDOR_ID) {
+            if (is_readable($vendorPath) && trim(file_get_contents($vendorPath)) === HardwareDetectionService::INTEL_VENDOR_ID) {
                 return $node;
             }
         }
@@ -185,10 +183,10 @@ class HardwareDetectionService {
     private function validateQsvPlain(): bool {
         $process = new Process([
             'ffmpeg',
-            ...self::DEFAULT_ARGUMENTS,
+            ...HardwareDetectionService::DEFAULT_ARGUMENTS,
             '-hwaccel',
             'qsv',
-            ...self::VALIDATION_ARGUMENTS,
+            ...HardwareDetectionService::VALIDATION_ARGUMENTS,
         ]);
         $process->setTimeout(10);
         $process->run();

--- a/app/Services/Hardware/HardwareProfile.php
+++ b/app/Services/Hardware/HardwareProfile.php
@@ -5,6 +5,8 @@ namespace App\Services\Hardware;
 use App\Enums\HardwareType;
 
 class HardwareProfile {
+    const PROFILE_VERSION = 2;
+
     public function __construct(
         public bool $cuda,
         public ?string $qsv, // null | 'derive_vaapi' | 'derive_d3d11va'

--- a/app/Services/Hardware/HardwareProfile.php
+++ b/app/Services/Hardware/HardwareProfile.php
@@ -7,15 +7,15 @@ use App\Enums\HardwareType;
 class HardwareProfile {
     public function __construct(
         public bool $cuda,
-        public bool $qsv,
+        public ?string $qsv, // null | 'derive_vaapi' | 'derive_d3d11va'
         public bool $vaapi,
+        public ?string $vaapiDevice,
     ) {}
 
     public function best(): HardwareType {
         return match (true) {
             $this->cuda => HardwareType::CUDA,
-            $this->qsv => HardwareType::QSV,
-            $this->vaapi => HardwareType::VAAPI,
+            $this->qsv !== null => HardwareType::QSV,
             default => HardwareType::CPU,
         };
     }

--- a/tests/Unit/Services/FFmpeg/FFmpegCommandBuilderTest.php
+++ b/tests/Unit/Services/FFmpeg/FFmpegCommandBuilderTest.php
@@ -17,8 +17,9 @@ class FFmpegCommandBuilderTest extends TestCase {
     private function makeBuilder(HardwareType $type): FFmpegCommandBuilder {
         $profile = new HardwareProfile(
             cuda: $type === HardwareType::CUDA,
-            qsv: $type === HardwareType::QSV,
+            qsv: $type === HardwareType::QSV ? 'derive_vaapi' : null,
             vaapi: $type === HardwareType::VAAPI,
+            vaapiDevice: HardwareType::QSV ? '/dev/dri/renderD128' : null,
         );
 
         $detector = $this->createMock(HardwareDetectionService::class);


### PR DESCRIPTION
### Fixes

- QSV based storyboard generation fails completely

### Changes

- Removed basic QSV storyboard generation
- Added vaapi and dx11 based storyboard generation via QSV
  - Vaapi derived QSV is very fast compared to basic QSV
  - 1.6s with Vaapi vs 27s with QSV and 14s with CPU for a 1.5gb video
